### PR TITLE
Avoid parsing arguments in migrator

### DIFF
--- a/src/TimeoutMigrationTool.AcceptanceTests/RavenDBToRabbitMqEndToEnd.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/RavenDBToRabbitMqEndToEnd.cs
@@ -46,7 +46,7 @@
             var transportAdapter = new RabbitMqTimeoutCreator(targetConnectionString);
             var migrationRunner = new MigrationRunner(timeoutStorage, transportAdapter);
 
-            await migrationRunner.Run(DateTime.Now.AddDays(-1), new Dictionary<string, string>());
+            await migrationRunner.Run(DateTime.Now.AddDays(-1), true, new Dictionary<string, string>());
 
             context = await Scenario.Define<Context>()
              .WithEndpoint<NewRabbitMqEndpoint>()

--- a/src/TimeoutMigrationTool.AcceptanceTests/RavenDBToRabbitMqEndToEnd.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/RavenDBToRabbitMqEndToEnd.cs
@@ -42,21 +42,11 @@
 
             var targetConnectionString = "amqp://guest:guest@localhost:5672";
 
-            var runParameters = new Dictionary<string, string>
-            {
-                { ApplicationOptions.CutoffTime, DateTime.Now.AddDays(-1).ToString() },
-                { ApplicationOptions.RavenServerUrl, serverUrl },
-                { ApplicationOptions.RabbitMqTargetConnectionString, targetConnectionString },
-                { ApplicationOptions.RavenDatabaseName, datebaseName },
-                { ApplicationOptions.RavenTimeoutPrefix, ravenTimeoutPrefix },
-                { ApplicationOptions.RavenVersion, ravenVersion.ToString() }
-            };
-
             var timeoutStorage = new RavenDBTimeoutStorage(serverUrl, datebaseName, ravenTimeoutPrefix, ravenVersion);
             var transportAdapter = new RabbitMqTimeoutCreator(targetConnectionString);
             var migrationRunner = new MigrationRunner(timeoutStorage, transportAdapter);
 
-            await migrationRunner.Run(runParameters);
+            await migrationRunner.Run(DateTime.Now.AddDays(-1), new Dictionary<string, string>());
 
             context = await Scenario.Define<Context>()
              .WithEndpoint<NewRabbitMqEndpoint>()

--- a/src/TimeoutMigrationTool/MigrationRunner.cs
+++ b/src/TimeoutMigrationTool/MigrationRunner.cs
@@ -14,9 +14,8 @@ namespace Particular.TimeoutMigrationTool
             this.transportTimeoutsCreator = transportTimeoutsCreator;
         }
 
-        public async Task Run(DateTime cutOffTime, IDictionary<string, string> runParameters)
+        public async Task Run(DateTime cutOffTime, bool forceMigration, IDictionary<string, string> runParameters)
         {
-            var forceMigration = runParameters.ContainsKey(ApplicationOptions.ForceMigration);
             if (forceMigration)
             {
                 await Console.Out.WriteAsync("Migration will be forced.").ConfigureAwait(false);

--- a/src/TimeoutMigrationTool/Program.cs
+++ b/src/TimeoutMigrationTool/Program.cs
@@ -192,7 +192,9 @@
                 }
             }
 
-            return migrationRunner.Run(cutOffTime, runParameters);
+            var forceMigration = runParameters.ContainsKey(ApplicationOptions.ForceMigration);
+
+            return migrationRunner.Run(cutOffTime, forceMigration, runParameters);
         }
     }
 }


### PR DESCRIPTION
I would like to propose a design where we don't parse the "common" arguments inside the migrator but rather pass them to the call to Run. I think that makes the code inside the migrator easier to read. Thoughts?