### PR TITLE
Prepare data for migration

### DIFF
--- a/src/TimeoutMigrationTool.AcceptanceTests/MsSqlMicrosoftDataClientHelper.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/MsSqlMicrosoftDataClientHelper.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 
-public static class MsSqlMicrosoftDataClientConnectionBuilder
+public static class MsSqlMicrosoftDataClientHelper
 {
     const string ConnectionString = @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Test;Integrated Security=True;Initial Catalog=Test;";
 
@@ -36,6 +37,21 @@ public static class MsSqlMicrosoftDataClientConnectionBuilder
 
                 command.CommandText = $"CREATE DATABASE {databaseName} COLLATE SQL_Latin1_General_CP1_CS_AS";
                 command.ExecuteNonQuery();
+            }
+        }
+    }
+
+    public static async Task<T> QueryScalarAsync<T>(string sqlStatement)
+    {
+        using (var connection = Build())
+        {
+            connection.Open();
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = sqlStatement;
+
+                return (T)await command.ExecuteScalarAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/TimeoutMigrationTool.AcceptanceTests/SetUpFixture.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/SetUpFixture.cs
@@ -6,6 +6,6 @@ public class SetUpFixture
     [OneTimeSetUp]
     public void SetUp()
     {
-        MsSqlMicrosoftDataClientConnectionBuilder.RecreateDbIfNotExists();
+        MsSqlMicrosoftDataClientHelper.RecreateDbIfNotExists();
     }
 }

--- a/src/TimeoutMigrationTool.AcceptanceTests/SqlPEndpoint.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/SqlPEndpoint.cs
@@ -32,7 +32,7 @@
             transport.UseNativeDelayedDelivery(false);
 
             var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
-            var connection = MsSqlMicrosoftDataClientConnectionBuilder.GetConnectionString();
+            var connection = MsSqlMicrosoftDataClientHelper.GetConnectionString();
 
             persistence.SqlDialect<SqlDialect.MsSqlServer>();
             persistence.ConnectionBuilder(

--- a/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
@@ -138,6 +138,35 @@ namespace TimeoutMigrationTool.AcceptanceTests
         }
 
         [Test]
+        public async Task Batches_Completed_Can_Be_Completed()
+        {
+            SqlP_WithTimeouts_Endpoint.EndpointName = "Batches_Completed_Can_Be_Completed";
+
+            var context = await Scenario.Define<Context>(c => c.NumberOfTimeouts = 10)
+                .WithEndpoint<SqlP_WithTimeouts_Endpoint>(b => b
+                    .When(session =>
+                    {
+                        var startSagaMessage = new StartSagaMessage { Id = Guid.NewGuid() };
+
+                        return session.SendLocal(startSagaMessage);
+                    }))
+                .Done(c => c.TimeoutsSet)
+                .Run();
+
+            var timeoutStorage = new SqlTimeoutStorage(MsSqlMicrosoftDataClientHelper.GetConnectionString(), Particular.TimeoutMigrationTool.SqlDialect.Parse("MsSql"), SqlP_WithTimeouts_Endpoint.EndpointName, 3, "");
+            var batches = await timeoutStorage.Prepare(DateTime.Now.AddYears(10));
+
+            foreach (var batch in batches)
+            {
+                await timeoutStorage.CompleteBatch(batch.Number);
+            }
+
+            var loadedState = await timeoutStorage.GetToolState();
+
+            Assert.IsTrue(loadedState.Batches.All(b => b.State == BatchState.Completed));
+        }
+
+        [Test]
         public async Task Timeouts_Split_Can_Be_Read_By_Batch()
         {
             SqlP_WithTimeouts_Endpoint.EndpointName = "Timeouts_Split_Can_Be_Read_By_Batch";

--- a/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
@@ -1,0 +1,155 @@
+﻿using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.Persistence.Sql;
+using NUnit.Framework;
+using Particular.TimeoutMigrationTool;
+using Particular.TimeoutMigrationTool.SqlP;
+using System;
+using System.Security.Cryptography.Xml;
+using System.Threading.Tasks;
+
+namespace TimeoutMigrationTool.AcceptanceTests
+{
+    [TestFixture]
+    class SqlTimeoutStorageTests : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Creates_TimeoutsMigration_State_Table()
+        {
+            SqlP_WithTimeouts_Endpoint.EndpointName = "Creates_TimeoutsMigration_State_Table";
+
+            var context = await Scenario.Define<Context>()
+            .WithEndpoint<SqlP_WithTimeouts_Endpoint>(b => b
+                .When(session =>
+                {
+                    var startSagaMessage = new StartSagaMessage { Id = Guid.NewGuid() };
+
+                    return session.SendLocal(startSagaMessage);
+                }))
+            .Done(c => c.TimeoutsSet)
+            .Run();
+
+            var timeoutStorage = new SqlTimeoutStorage(MsSqlMicrosoftDataClientHelper.GetConnectionString(), Particular.TimeoutMigrationTool.SqlDialect.Parse("MsSql"), SqlP_WithTimeouts_Endpoint.EndpointName, 1024, "");
+            await timeoutStorage.Prepare(DateTime.Now.AddYears(9).AddMonths(6));
+
+            var numberOfBatches = await MsSqlMicrosoftDataClientHelper.QueryScalarAsync<int>($"SELECT TOP 1 Batches FROM TimeoutsMigration_State WHERE EndpointName = '{SqlP_WithTimeouts_Endpoint.EndpointName}'");
+
+            Assert.AreEqual(1, numberOfBatches);
+        }
+
+        [Test]
+        public async Task Splits_timeouts_into_correct_number_of_batches()
+        {
+            SqlP_WithTimeouts_Endpoint.EndpointName = "Splits_timeouts_into_correct_number_of_batches";
+
+            var context = await Scenario.Define<Context>()
+            .WithEndpoint<SqlP_WithTimeouts_Endpoint>(b => b
+                .When(session =>
+                {
+                    var startSagaMessage = new StartSagaMessage { Id = Guid.NewGuid() };
+
+                    return session.SendLocal(startSagaMessage);
+                }))
+            .Done(c => c.TimeoutsSet)
+            .Run();
+
+            var timeoutStorage = new SqlTimeoutStorage(MsSqlMicrosoftDataClientHelper.GetConnectionString(), Particular.TimeoutMigrationTool.SqlDialect.Parse("MsSql"), SqlP_WithTimeouts_Endpoint.EndpointName, 3, "");
+            await timeoutStorage.Prepare(DateTime.Now.AddYears(9).AddMonths(6));
+
+            var numberOfBatches = await MsSqlMicrosoftDataClientHelper.QueryScalarAsync<int>($"SELECT MAX(Batches) FROM TimeoutsMigration_State WHERE EndpointName = '{SqlP_WithTimeouts_Endpoint.EndpointName}'");
+
+            Assert.AreEqual(4, numberOfBatches);
+        }
+
+        [Test]
+        public async Task Removes_Timeouts_From_Original_TimeoutData_Table()
+        {
+            // todo
+            SqlP_WithTimeouts_Endpoint.EndpointName = "Splits_timeouts_into_correct_number_of_batches";
+
+            var context = await Scenario.Define<Context>()
+            .WithEndpoint<SqlP_WithTimeouts_Endpoint>(b => b
+                .When(session =>
+                {
+                    var startSagaMessage = new StartSagaMessage { Id = Guid.NewGuid() };
+
+                    return session.SendLocal(startSagaMessage);
+                }))
+            .Done(c => c.TimeoutsSet)
+            .Run();
+
+            var timeoutStorage = new SqlTimeoutStorage(MsSqlMicrosoftDataClientHelper.GetConnectionString(), Particular.TimeoutMigrationTool.SqlDialect.Parse("MsSql"), SqlP_WithTimeouts_Endpoint.EndpointName, 3, "");
+            await timeoutStorage.Prepare(DateTime.Now.AddYears(9).AddMonths(6));
+
+            var numberOfBatches = await MsSqlMicrosoftDataClientHelper.QueryScalarAsync<int>($"SELECT MAX(Batches) FROM TimeoutsMigration_State WHERE EndpointName = '{SqlP_WithTimeouts_Endpoint.EndpointName}'");
+
+            Assert.AreEqual(4, numberOfBatches);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool TimeoutsSet { get; set; }
+        }
+
+        public class SqlP_WithTimeouts_Endpoint : EndpointConfigurationBuilder
+        {
+            public static string EndpointName { get; set; }
+
+            public SqlP_WithTimeouts_Endpoint()
+            {
+                if (!string.IsNullOrWhiteSpace(EndpointName))
+                {
+                    CustomEndpointName(EndpointName);
+                }
+
+                EndpointSetup<SqlPEndpoint>(config =>
+                {
+                });
+            }
+
+            [SqlSaga(correlationProperty: nameof(TestSaga.Id))]
+            public class TimeoutSaga : Saga<TestSaga>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<Timeout>
+            {
+                // ReSharper disable once MemberCanBePrivate.Global
+                public Context TestContext { get; set; }
+
+                public async Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    for (var x = 0; x < 10; x++)
+                    {
+                        await RequestTimeout(context, DateTime.Now.AddDays(7 + x), new Timeout { Id = message.Id });
+                    }
+                    await RequestTimeout(context, DateTime.Now.AddSeconds(0.1), new Timeout { Id = message.Id }); // Wait for the timeout messages to be sent to the timeout manager
+                }
+
+                public Task Timeout(Timeout state, IMessageHandlerContext context)
+                {
+                    TestContext.TimeoutsSet = true;
+
+                    return Task.CompletedTask;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSaga> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(a => a.Id).ToSaga(s => s.Id);
+                    mapper.ConfigureMapping<Timeout>(a => a.Id).ToSaga(s => s.Id);
+                }
+            }
+        }
+
+        public class TestSaga : ContainSagaData
+        {
+            public override Guid Id { get; set; }
+        }
+
+        public class Timeout
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class StartSagaMessage : ICommand
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
@@ -54,11 +54,9 @@ namespace TimeoutMigrationTool.AcceptanceTests
             .Run();
 
             var timeoutStorage = new SqlTimeoutStorage(MsSqlMicrosoftDataClientHelper.GetConnectionString(), Particular.TimeoutMigrationTool.SqlDialect.Parse("MsSql"), SqlP_WithTimeouts_Endpoint.EndpointName, 3, "");
-            await timeoutStorage.Prepare(DateTime.Now.AddYears(9).AddMonths(6));
+            var batchInfo = await timeoutStorage.Prepare(DateTime.Now.AddYears(9).AddMonths(6));
 
-            var numberOfBatches = await MsSqlMicrosoftDataClientHelper.QueryScalarAsync<int>($"SELECT MAX(Batches) FROM TimeoutsMigration_State WHERE EndpointName = '{SqlP_WithTimeouts_Endpoint.EndpointName}'");
-
-            Assert.AreEqual(4, numberOfBatches);
+            Assert.AreEqual(4, batchInfo.Count);
         }
 
         [Test]

--- a/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
@@ -89,7 +89,7 @@ namespace TimeoutMigrationTool.AcceptanceTests
         {
             SqlP_WithTimeouts_Endpoint.EndpointName = "Splits_timeouts_including_cutoff_date";
 
-            var context = await Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>(c => c.NumberOfTimeouts = 10)
                 .WithEndpoint<SqlP_WithTimeouts_Endpoint>(b => b
                     .When(session =>
                     {
@@ -105,7 +105,7 @@ namespace TimeoutMigrationTool.AcceptanceTests
 
             var numberOfBatches = await MsSqlMicrosoftDataClientHelper.QueryScalarAsync<int>($"SELECT MAX(Batches) FROM TimeoutsMigration_State WHERE EndpointName = '{SqlP_WithTimeouts_Endpoint.EndpointName}'");
 
-            Assert.AreEqual(3, numberOfBatches);
+            Assert.AreEqual(4, numberOfBatches);
         }
 
         [Test]

--- a/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutStorageTests.cs
@@ -65,7 +65,7 @@ namespace TimeoutMigrationTool.AcceptanceTests
         public async Task Removes_Timeouts_From_Original_TimeoutData_Table()
         {
             // todo
-            SqlP_WithTimeouts_Endpoint.EndpointName = "Splits_timeouts_into_correct_number_of_batches";
+            SqlP_WithTimeouts_Endpoint.EndpointName = "Removes_Timeouts_From_Original_TimeoutData_Table";
 
             var context = await Scenario.Define<Context>()
             .WithEndpoint<SqlP_WithTimeouts_Endpoint>(b => b
@@ -81,9 +81,9 @@ namespace TimeoutMigrationTool.AcceptanceTests
             var timeoutStorage = new SqlTimeoutStorage(MsSqlMicrosoftDataClientHelper.GetConnectionString(), Particular.TimeoutMigrationTool.SqlDialect.Parse("MsSql"), SqlP_WithTimeouts_Endpoint.EndpointName, 3, "");
             await timeoutStorage.Prepare(DateTime.Now.AddYears(9).AddMonths(6));
 
-            var numberOfBatches = await MsSqlMicrosoftDataClientHelper.QueryScalarAsync<int>($"SELECT MAX(Batches) FROM TimeoutsMigration_State WHERE EndpointName = '{SqlP_WithTimeouts_Endpoint.EndpointName}'");
+            var numberOfBatches = await MsSqlMicrosoftDataClientHelper.QueryScalarAsync<int>($"SELECT COUNT(*) FROM {SqlP_WithTimeouts_Endpoint.EndpointName}_TimeoutData");
 
-            Assert.AreEqual(4, numberOfBatches);
+            Assert.AreEqual(0, numberOfBatches);
         }
 
         public class Context : ScenarioContext

--- a/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutsReaderTests.cs
+++ b/src/TimeoutMigrationTool.AcceptanceTests/SqlTimeoutsReaderTests.cs
@@ -28,7 +28,7 @@ namespace TimeoutMigrationTool.AcceptanceTests
             ;
 
             var reader = new SqlTimeoutsReader();
-            var timeouts = await reader.ReadTimeoutsFrom(MsSqlMicrosoftDataClientConnectionBuilder.GetConnectionString(), "Sqltimeoutsreadertests_SqlP_WithTimeouts_Endpoint_TimeoutData", new MsSqlServer(), new System.Threading.CancellationToken());
+            var timeouts = await reader.ReadTimeoutsFrom(MsSqlMicrosoftDataClientHelper.GetConnectionString(), "Sqltimeoutsreadertests_SqlP_WithTimeouts_Endpoint_TimeoutData", new MsSqlServer(), new System.Threading.CancellationToken());
 
             Assert.AreEqual(1, timeouts?.Count);
         }

--- a/src/TimeoutMigrationTool/MigrationRunner.cs
+++ b/src/TimeoutMigrationTool/MigrationRunner.cs
@@ -145,7 +145,9 @@ namespace Particular.TimeoutMigrationTool
 
         async Task CompleteCurrentBatch(ToolState toolState)
         {
-            toolState.GetCurrentBatch().State = BatchState.Completed;
+            var currentBatch = toolState.GetCurrentBatch();
+            currentBatch.State = BatchState.Completed;
+            await timeoutStorage.CompleteBatch(currentBatch.Number);
             await timeoutStorage.StoreToolState(toolState);
         }
 

--- a/src/TimeoutMigrationTool/Program.cs
+++ b/src/TimeoutMigrationTool/Program.cs
@@ -79,7 +79,7 @@
                     runParameters.Add(ApplicationOptions.SqlTimeoutTableName, timeoutTableName);
                     runParameters.Add(ApplicationOptions.SqlSourceDialect, sourceDialect.Value());
 
-                    var timeoutStorage = new SqlTimeoutStorage(sourceConnectionString, dialect, timeoutTableName);
+                    var timeoutStorage = new SqlTimeoutStorage(sourceConnectionString, dialect, timeoutTableName, 1024, "run parameters jason thing goes here");
                     var transportAdapter = new RabbitMqTimeoutCreator(targetConnectionString);
 
                     await RunMigration(runParameters, timeoutStorage, transportAdapter);

--- a/src/TimeoutMigrationTool/SqlDialect.cs
+++ b/src/TimeoutMigrationTool/SqlDialect.cs
@@ -102,7 +102,7 @@ BEGIN TRANSACTION
         FROM [{endpointName}_TimeoutData_migration]
     ) BatchMigration;
 
-    INSERT INTO TimeoutsMigration_State VALUES ('{endpointName}', 'Prepared', (SELECT COUNT(DISTINCT BatchNumber) from [{endpointName}_TimeoutData_migration]), @RunParameters);
+    INSERT INTO TimeoutsMigration_State VALUES ('{endpointName}', 'StoragePrepared', (SELECT COUNT(DISTINCT BatchNumber) from [{endpointName}_TimeoutData_migration]), @RunParameters);
 
      SELECT
         Id,

--- a/src/TimeoutMigrationTool/SqlDialect.cs
+++ b/src/TimeoutMigrationTool/SqlDialect.cs
@@ -14,7 +14,9 @@ namespace Particular.TimeoutMigrationTool
             return new MsSqlServer();
         }
 
-        public abstract string GetScriptToPrepareTimeouts(string originalTableName, int batchSize);
+        public abstract string GetScriptToPrepareTimeouts(string endpointName, int batchSize);
+        public abstract string GetScriptToLoadBatchInfo(string endpointName);
+        public abstract string GetScriptToLoadToolState(string endpointName);
     }
 
     public class MsSqlServer : SqlDialect
@@ -25,6 +27,32 @@ namespace Particular.TimeoutMigrationTool
             connection.Open();
 
             return connection;
+        }
+
+        public override string GetScriptToLoadBatchInfo(string endpointName)
+        {
+            return $@"SELECT
+    Id,
+    BatchNumber,
+    Status
+FROM
+    [{endpointName}_TimeoutData_migration];";
+        }
+
+        public override string GetScriptToLoadToolState(string endpointName)
+        {
+            // Batches
+            // RunParameters
+            // Status
+            return $@"SELECT
+    EndpointName,
+    Status,
+    RunParameters
+FROM
+    TimeoutsMigration_State
+WHERE
+    EndpointName = '{endpointName}';
+";
         }
 
         public override string GetScriptToPrepareTimeouts(string endpointName, int batchSize)
@@ -94,6 +122,16 @@ COMMIT;";
             throw new NotImplementedException();
         }
 
+        public override string GetScriptToLoadBatchInfo(string endpointName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToLoadToolState(string endpointName)
+        {
+            throw new NotImplementedException();
+        }
+
         public override string GetScriptToPrepareTimeouts(string originalTableName, int batchSize)
         {
             throw new NotImplementedException();
@@ -107,6 +145,16 @@ COMMIT;";
             throw new NotImplementedException();
         }
 
+        public override string GetScriptToLoadBatchInfo(string endpointName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToLoadToolState(string endpointName)
+        {
+            throw new NotImplementedException();
+        }
+
         public override string GetScriptToPrepareTimeouts(string originalTableName, int batchSize)
         {
             throw new NotImplementedException();
@@ -116,6 +164,16 @@ COMMIT;";
     public class PostgreSql : SqlDialect
     {
         public override DbConnection Connect(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToLoadBatchInfo(string endpointName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToLoadToolState(string endpointName)
         {
             throw new NotImplementedException();
         }

--- a/src/TimeoutMigrationTool/SqlDialect.cs
+++ b/src/TimeoutMigrationTool/SqlDialect.cs
@@ -45,7 +45,7 @@ BEGIN TRANSACTION
     CREATE TABLE [{endpointName}_TimeoutData_migration] (
         Id UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
         BatchNumber INT,
-        Status INT, /* NULL = prepared, 1 = staged, 2 = migrated */
+        Status INT NOT NULL, /* 0 = Pending, 1 = staged, 2 = migrated */
         Destination NVARCHAR(200),
         SagaId UNIQUEIDENTIFIER,
         State VARBINARY(MAX),
@@ -57,7 +57,7 @@ BEGIN TRANSACTION
     DELETE [{endpointName}_TimeoutData]
     OUTPUT DELETED.Id,
         -1,
-        NULL,
+        0,
         DELETED.Destination,
         DELETED.SagaId,
         DELETED.State,
@@ -75,7 +75,14 @@ BEGIN TRANSACTION
     ) BatchMigration;
 
     INSERT INTO TimeoutsMigration_State VALUES ('{endpointName}', 'Prepared', (SELECT COUNT(DISTINCT BatchNumber) from [{endpointName}_TimeoutData_migration]), @RunParameters);
-        
+
+     SELECT
+        Id,
+        BatchNumber,
+        Status
+    FROM
+        [{endpointName}_TimeoutData_migration];
+
 COMMIT;";
         }
     }

--- a/src/TimeoutMigrationTool/SqlDialect.cs
+++ b/src/TimeoutMigrationTool/SqlDialect.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Data.SqlClient;
 using System;
 using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace Particular.TimeoutMigrationTool
 {
@@ -12,6 +13,8 @@ namespace Particular.TimeoutMigrationTool
         {
             return new MsSqlServer();
         }
+
+        public abstract string GetScriptToPrepareTimeouts(string originalTableName, int batchSize);
     }
 
     public class MsSqlServer : SqlDialect
@@ -23,11 +26,64 @@ namespace Particular.TimeoutMigrationTool
 
             return connection;
         }
+
+        public override string GetScriptToPrepareTimeouts(string originalTableName, int batchSize)
+        {
+            return $@"
+BEGIN TRANSACTION
+
+    CREATE TABLE MigrationState (
+        Status VARCHAR(15) NOT NULL,
+        Batches INT NOT NULL,
+        RunParameters NVARCHAR(MAX)
+    );
+
+    CREATE TABLE [{originalTableName}_migration] (
+        Id UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
+        BatchNumber INT,
+        Status INT, /* NULL = prepared, 1 = staged, 2 = migrated */
+        Destination NVARCHAR(200),
+        SagaId UNIQUEIDENTIFIER,
+        State VARBINARY(MAX),
+        Time DATETIME,
+        Headers NVARCHAR(MAX) NOT NULL,
+        PersistenceVersion VARCHAR(23) NOT NULL
+    );
+
+    DELETE [{originalTableName}]
+    OUTPUT DELETED.Id,
+        -1,
+        NULL,
+        DELETED.Destination,
+        DELETED.SagaId,
+        DELETED.State,
+        DELETED.Time,
+        DELETED.Headers,
+        DELETED.PersistenceVersion
+    INTO [{originalTableName}_migration]
+    WHERE [{originalTableName}].Time <= @maxCutOff;
+
+    UPDATE BatchMigration
+    SET BatchMigration.BatchNumber = BatchMigration.CalculatedBatchNumber
+    FROM (
+        SELECT BatchNumber, ROW_NUMBER() OVER (ORDER BY (select 0)) / {batchSize} AS CalculatedBatchNumber
+        FROM [{originalTableName}_migration]
+    ) BatchMigration;
+
+    INSERT INTO MigrationState VALUES ('Prepared', (SELECT COUNT(DISTINCT BatchNumber) from [{originalTableName}_migration]), @RunParameters);
+        
+COMMIT;";
+        }
     }
 
     public class Oracle : SqlDialect
     {
         public override DbConnection Connect(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToPrepareTimeouts(string originalTableName, int batchSize)
         {
             throw new NotImplementedException();
         }
@@ -39,11 +95,21 @@ namespace Particular.TimeoutMigrationTool
         {
             throw new NotImplementedException();
         }
+
+        public override string GetScriptToPrepareTimeouts(string originalTableName, int batchSize)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class PostgreSql : SqlDialect
     {
         public override DbConnection Connect(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToPrepareTimeouts(string originalTableName, int batchSize)
         {
             throw new NotImplementedException();
         }

--- a/src/TimeoutMigrationTool/SqlP/SqlDialect.cs
+++ b/src/TimeoutMigrationTool/SqlP/SqlDialect.cs
@@ -19,6 +19,7 @@ namespace Particular.TimeoutMigrationTool
         public abstract string GetScriptToLoadToolState(string endpointName);
         public abstract string GetScriptToStoreToolState(string endpointName);
         public abstract string GetScriptToLoadBatch(string endpointName);
+        public abstract string GetScriptToAbortBatch(string timeoutTableName);
     }
 
     public class MsSqlServer : SqlDialect
@@ -128,6 +129,30 @@ BEGIN TRANSACTION
 COMMIT;";
         }
 
+        public override string GetScriptToAbortBatch(string endpointName)
+        {
+            return $@"BEGIN TRANSACTION
+
+DELETE [{endpointName}_TimeoutData_migration]
+    OUTPUT DELETED.Id,
+        DELETED.Destination,
+        DELETED.SagaId,
+        DELETED.State,
+        DELETED.Time,
+        DELETED.Headers,
+        DELETED.PersistenceVersion
+    INTO [{endpointName}_TimeoutData];
+
+    DELETE
+        TimeoutsMigration_State
+    WHERE
+        EndpointName = '{endpointName}';
+
+    DROP TABLE [{endpointName}_TimeoutData_migration];
+
+COMMIT;";
+        }
+
         public override string GetScriptToStoreToolState(string endpointName)
         {
             return $@"UPDATE
@@ -142,6 +167,11 @@ WHERE
     public class Oracle : SqlDialect
     {
         public override DbConnection Connect(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToAbortBatch(string timeoutTableName)
         {
             throw new NotImplementedException();
         }
@@ -179,6 +209,11 @@ WHERE
             throw new NotImplementedException();
         }
 
+        public override string GetScriptToAbortBatch(string timeoutTableName)
+        {
+            throw new NotImplementedException();
+        }
+
         public override string GetScriptToLoadBatch(string endpointName)
         {
             throw new NotImplementedException();
@@ -208,6 +243,11 @@ WHERE
     public class PostgreSql : SqlDialect
     {
         public override DbConnection Connect(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToAbortBatch(string timeoutTableName)
         {
             throw new NotImplementedException();
         }

--- a/src/TimeoutMigrationTool/SqlP/SqlDialect.cs
+++ b/src/TimeoutMigrationTool/SqlP/SqlDialect.cs
@@ -17,6 +17,7 @@ namespace Particular.TimeoutMigrationTool
         public abstract string GetScriptToPrepareTimeouts(string endpointName, int batchSize);
         public abstract string GetScriptToLoadBatchInfo(string endpointName);
         public abstract string GetScriptToLoadToolState(string endpointName);
+        public abstract string GetScriptToLoadBatch(string endpointName);
     }
 
     public class MsSqlServer : SqlDialect
@@ -27,6 +28,22 @@ namespace Particular.TimeoutMigrationTool
             connection.Open();
 
             return connection;
+        }
+
+        public override string GetScriptToLoadBatch(string endpointName)
+        {
+            return $@"SELECT Id,
+    Destination,
+    SagaId,
+    State,
+    Time,
+    Headers,
+    PersistenceVersion
+FROM
+    [{endpointName}_TimeoutData_migration]
+WHERE
+    BatchNumber = @BatchNumber;
+";
         }
 
         public override string GetScriptToLoadBatchInfo(string endpointName)
@@ -122,6 +139,11 @@ COMMIT;";
             throw new NotImplementedException();
         }
 
+        public override string GetScriptToLoadBatch(string endpointName)
+        {
+            throw new NotImplementedException();
+        }
+
         public override string GetScriptToLoadBatchInfo(string endpointName)
         {
             throw new NotImplementedException();
@@ -145,6 +167,11 @@ COMMIT;";
             throw new NotImplementedException();
         }
 
+        public override string GetScriptToLoadBatch(string endpointName)
+        {
+            throw new NotImplementedException();
+        }
+
         public override string GetScriptToLoadBatchInfo(string endpointName)
         {
             throw new NotImplementedException();
@@ -164,6 +191,11 @@ COMMIT;";
     public class PostgreSql : SqlDialect
     {
         public override DbConnection Connect(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToLoadBatch(string endpointName)
         {
             throw new NotImplementedException();
         }

--- a/src/TimeoutMigrationTool/SqlP/SqlDialect.cs
+++ b/src/TimeoutMigrationTool/SqlP/SqlDialect.cs
@@ -17,6 +17,7 @@ namespace Particular.TimeoutMigrationTool
         public abstract string GetScriptToPrepareTimeouts(string endpointName, int batchSize);
         public abstract string GetScriptToLoadBatchInfo(string endpointName);
         public abstract string GetScriptToLoadToolState(string endpointName);
+        public abstract string GetScriptToStoreToolState(string endpointName);
         public abstract string GetScriptToLoadBatch(string endpointName);
     }
 
@@ -58,9 +59,6 @@ FROM
 
         public override string GetScriptToLoadToolState(string endpointName)
         {
-            // Batches
-            // RunParameters
-            // Status
             return $@"SELECT
     EndpointName,
     Status,
@@ -68,8 +66,7 @@ FROM
 FROM
     TimeoutsMigration_State
 WHERE
-    EndpointName = '{endpointName}';
-";
+    EndpointName = '{endpointName}';";
         }
 
         public override string GetScriptToPrepareTimeouts(string endpointName, int batchSize)
@@ -130,6 +127,16 @@ BEGIN TRANSACTION
 
 COMMIT;";
         }
+
+        public override string GetScriptToStoreToolState(string endpointName)
+        {
+            return $@"UPDATE
+    TimeoutsMigration_State
+SET
+    Status = @Status
+WHERE
+    EndpointName = '{endpointName}';";
+        }
     }
 
     public class Oracle : SqlDialect
@@ -155,6 +162,11 @@ COMMIT;";
         }
 
         public override string GetScriptToPrepareTimeouts(string originalTableName, int batchSize)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToStoreToolState(string endpointName)
         {
             throw new NotImplementedException();
         }
@@ -186,6 +198,11 @@ COMMIT;";
         {
             throw new NotImplementedException();
         }
+
+        public override string GetScriptToStoreToolState(string endpointName)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class PostgreSql : SqlDialect
@@ -211,6 +228,11 @@ COMMIT;";
         }
 
         public override string GetScriptToPrepareTimeouts(string originalTableName, int batchSize)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToStoreToolState(string endpointName)
         {
             throw new NotImplementedException();
         }

--- a/src/TimeoutMigrationTool/SqlP/SqlDialect.cs
+++ b/src/TimeoutMigrationTool/SqlP/SqlDialect.cs
@@ -19,7 +19,8 @@ namespace Particular.TimeoutMigrationTool
         public abstract string GetScriptToLoadToolState(string endpointName);
         public abstract string GetScriptToStoreToolState(string endpointName);
         public abstract string GetScriptToLoadBatch(string endpointName);
-        public abstract string GetScriptToAbortBatch(string timeoutTableName);
+        public abstract string GetScriptToAbortBatch(string endpointName);
+        public abstract string GetScriptToCompleteBatch(string endpointName);
     }
 
     public class MsSqlServer : SqlDialect
@@ -162,6 +163,16 @@ SET
 WHERE
     EndpointName = '{endpointName}';";
         }
+
+        public override string GetScriptToCompleteBatch(string endpointName)
+        {
+            return $@"UPDATE
+    [{endpointName}_TimeoutData_migration]
+SET
+    Status = 2
+WHERE
+    BatchNumber = @BatchNumber";
+        }
     }
 
     public class Oracle : SqlDialect
@@ -172,6 +183,11 @@ WHERE
         }
 
         public override string GetScriptToAbortBatch(string timeoutTableName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToCompleteBatch(string timeoutTableName)
         {
             throw new NotImplementedException();
         }
@@ -214,6 +230,11 @@ WHERE
             throw new NotImplementedException();
         }
 
+        public override string GetScriptToCompleteBatch(string timeoutTableName)
+        {
+            throw new NotImplementedException();
+        }
+
         public override string GetScriptToLoadBatch(string endpointName)
         {
             throw new NotImplementedException();
@@ -248,6 +269,11 @@ WHERE
         }
 
         public override string GetScriptToAbortBatch(string timeoutTableName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetScriptToCompleteBatch(string timeoutTableName)
         {
             throw new NotImplementedException();
         }

--- a/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
+++ b/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
@@ -108,12 +108,12 @@
 
         MigrationStatus ParseMigrationStatus(string status)
         {
-            return MigrationStatus.Completed;
+            return (MigrationStatus)Enum.Parse(typeof(MigrationStatus), status);
         }
 
         BatchState GetBatchStatus(int dbStatus)
         {
-            return BatchState.Pending;
+            return (BatchState)dbStatus;
         }
 
         public Task<List<TimeoutData>> ReadBatch(int batchNumber)

--- a/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
+++ b/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
@@ -126,9 +126,17 @@
             }
         }
 
-        public Task Abort(ToolState toolState)
+        public async Task Abort(ToolState toolState)
         {
-            throw new NotImplementedException();
+            using (var connection = dialect.Connect(connectionString))
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = dialect.GetScriptToAbortBatch(timeoutTableName);
+
+                    await command.ExecuteNonQueryAsync();
+                }
+            }
         }
 
         public Task<bool> CanPrepareStorage()

--- a/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
+++ b/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
@@ -1,7 +1,6 @@
-﻿using System;
-
-namespace Particular.TimeoutMigrationTool.SqlP
+﻿namespace Particular.TimeoutMigrationTool.SqlP
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
@@ -9,7 +8,7 @@ namespace Particular.TimeoutMigrationTool.SqlP
     {
         public SqlTimeoutStorage(string sourceConnectionString, SqlDialect dialect, string timeoutTableName)
         {
-            this.sourceConnectionString = sourceConnectionString;
+            connectionString = sourceConnectionString;
             this.dialect = dialect;
             this.timeoutTableName = timeoutTableName;
         }
@@ -19,9 +18,27 @@ namespace Particular.TimeoutMigrationTool.SqlP
             throw new System.NotImplementedException();
         }
 
-        public Task<List<BatchInfo>> Prepare(DateTime maxCutoffTime)
+        public async Task<List<BatchInfo>> Prepare(DateTime maxCutoffTime)
         {
-            throw new System.NotImplementedException();
+            using (var connection = dialect.Connect(connectionString))
+            {
+                var command = connection.CreateCommand();
+                command.CommandText = dialect.GetScriptToPrepareTimeouts(timeoutTableName, 5);
+
+                var cutOffParameter = command.CreateParameter();
+                cutOffParameter.ParameterName = "maxCutOff";
+                cutOffParameter.Value = maxCutoffTime;
+                command.Parameters.Add(cutOffParameter);
+
+                var runParametersParameter = command.CreateParameter();
+                runParametersParameter.ParameterName = "RunParameters";
+                runParametersParameter.Value = "...where do I get this from?";
+                command.Parameters.Add(runParametersParameter);
+
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+                return null;
+            }
         }
 
         public Task<List<TimeoutData>> ReadBatch(int batchNumber)
@@ -49,7 +66,7 @@ namespace Particular.TimeoutMigrationTool.SqlP
             throw new NotImplementedException();
         }
 
-        readonly string sourceConnectionString;
+        readonly string connectionString;
         readonly SqlDialect dialect;
         readonly string timeoutTableName;
     }

--- a/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
+++ b/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
@@ -102,9 +102,23 @@
             return null;
         }
 
-        public Task CompleteBatch(int number)
+        public async Task CompleteBatch(int number)
         {
-            throw new System.NotImplementedException();
+            using (var connection = dialect.Connect(connectionString))
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = dialect.GetScriptToCompleteBatch(timeoutTableName);
+
+                    var parameter = command.CreateParameter();
+                    parameter.ParameterName = "BatchNumber";
+                    parameter.Value = number;
+
+                    command.Parameters.Add(parameter);
+
+                    await command.ExecuteNonQueryAsync();
+                }
+            }
         }
 
         public async Task StoreToolState(ToolState toolState)

--- a/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
+++ b/src/TimeoutMigrationTool/SqlP/SqlTimeoutStorage.cs
@@ -5,6 +5,7 @@
     using System.Collections.Generic;
     using System.Data.Common;
     using System.Threading.Tasks;
+    using Newtonsoft.Json;
 
     public class SqlTimeoutStorage : ITimeoutStorage
     {
@@ -72,6 +73,53 @@
             }
         }
 
+        public async Task<List<TimeoutData>> ReadBatch(int batchNumber)
+        {
+            using (var connection = dialect.Connect(connectionString))
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = dialect.GetScriptToLoadBatch(timeoutTableName);
+
+                    var parameter = command.CreateParameter();
+                    parameter.ParameterName = "BatchNumber";
+                    parameter.Value = batchNumber;
+
+                    command.Parameters.Add(parameter);
+
+                    using (var reader = await command.ExecuteReaderAsync().ConfigureAwait(false))
+                    {
+                        if (reader.HasRows)
+                        {
+                            return ReadTimeoutDataRows(reader).ToList();
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public Task CompleteBatch(int number)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task StoreToolState(ToolState toolState)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task Abort(ToolState toolState)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> CanPrepareStorage()
+        {
+            throw new NotImplementedException();
+        }
+
         async Task<List<BatchInfo>> ReadBatchInfo(DbCommand command)
         {
             var batches = new List<BatchInfo>();
@@ -116,30 +164,60 @@
             return (BatchState)dbStatus;
         }
 
-        public Task<List<TimeoutData>> ReadBatch(int batchNumber)
+        IEnumerable<TimeoutData> ReadTimeoutDataRows(DbDataReader reader)
         {
-            throw new System.NotImplementedException();
+            while (reader.Read())
+            {
+                yield return new TimeoutData
+                {
+                    Id = reader.GetGuid(0).ToString(),
+                    Destination = reader.GetString(1),
+                    SagaId = reader.GetGuid(2),
+                    State = GetBytes(reader, 3),
+                    Time = reader.GetFieldValue<DateTime>(4),
+                    Headers = GetHeaders(reader)
+                };
+            }
         }
 
-        public Task CompleteBatch(int number)
+        byte[] GetBytes(DbDataReader reader, int ordinal)
         {
-            throw new System.NotImplementedException();
+            byte[] result = null;
+
+            if (!reader.IsDBNull(ordinal))
+            {
+                long size = reader.GetBytes(ordinal, 0, null, 0, 0);
+                result = new byte[size];
+                int bufferSize = 1024;
+                long bytesRead = 0;
+                int curPos = 0;
+
+                while (bytesRead < size)
+                {
+                    bytesRead += reader.GetBytes(ordinal, curPos, result, curPos, bufferSize);
+                    curPos += bufferSize;
+                }
+            }
+
+            return result;
         }
 
-        public Task StoreToolState(ToolState toolState)
+        private Dictionary<string, string> GetHeaders(DbDataReader reader)
         {
-            throw new System.NotImplementedException();
+            using (var stream = reader.GetTextReader(5))
+            {
+                using (var jsonReader = new JsonTextReader(stream))
+                {
+                    return serializer.Deserialize<Dictionary<string, string>>(jsonReader);
+                }
+            }
         }
 
-        public Task Abort(ToolState toolState)
+        static JsonSerializer serializer = JsonSerializer.Create(new JsonSerializerSettings
         {
-            throw new NotImplementedException();
-        }
-
-        public Task<bool> CanPrepareStorage()
-        {
-            throw new NotImplementedException();
-        }
+            Formatting = Formatting.Indented,
+            DefaultValueHandling = DefaultValueHandling.Ignore
+        });
 
         readonly SqlDialect dialect;
         readonly string connectionString;


### PR DESCRIPTION
Creates the migration state table and moves all timeouts to the table_migration table.

Does it within a single Tx, so all or nothing. Should be safe regardless of failure point.

Still to do:
  * Return the batch information
  * Find out where to get the run parameters from so they can be stored