### PR TITLE
Do not wrap http client in using

### DIFF
--- a/src/TimeoutMigrationTool.Raven3.Tests/RavenPreparesTheMigration.cs
+++ b/src/TimeoutMigrationTool.Raven3.Tests/RavenPreparesTheMigration.cs
@@ -1,18 +1,15 @@
-using System;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
-using NUnit.Framework;
-using Particular.TimeoutMigrationTool;
-using Particular.TimeoutMigrationTool.RavenDB;
-
 namespace TimeoutMigrationTool.Raven3.Tests
 {
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Particular.TimeoutMigrationTool;
+    using Particular.TimeoutMigrationTool.RavenDB;
+
     public class RavenPreparesTheMigration : RavenTimeoutStorageTestSuite
     {
-        private readonly int nrOfTimeouts = 1500;
-
         [SetUp]
         public async Task Setup()
         {
@@ -105,12 +102,9 @@ namespace TimeoutMigrationTool.Raven3.Tests
                 new RavenDBTimeoutStorage(ServerName, databaseName, "TimeoutDatas", RavenDbVersion.ThreeDotFive);
             await timeoutStorage.RemoveToolState();
 
-            using (var httpClient = new HttpClient())
-            {
-                var getStateUrl = $"{ServerName}/databases/{databaseName}/docs?id={RavenConstants.ToolStateId}";
-                var result = await httpClient.GetAsync(getStateUrl);
-                Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
-            }
+            var getStateUrl = $"{ServerName}/databases/{databaseName}/docs?id={RavenConstants.ToolStateId}";
+            var result = await httpClient.GetAsync(getStateUrl);
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
         [Test]
@@ -127,5 +121,7 @@ namespace TimeoutMigrationTool.Raven3.Tests
             var updatedToolState = await GetToolState();
             Assert.That(updatedToolState.Status, Is.EqualTo(MigrationStatus.StoragePrepared));
         }
+
+        private readonly int nrOfTimeouts = 1500;
     }
 }

--- a/src/TimeoutMigrationTool.Raven3.Tests/RavenTimeoutStorageTestSuite.cs
+++ b/src/TimeoutMigrationTool.Raven3.Tests/RavenTimeoutStorageTestSuite.cs
@@ -13,10 +13,6 @@ namespace TimeoutMigrationTool.Raven3.Tests
 
     public abstract class RavenTimeoutStorageTestSuite
     {
-        protected string ServerName = (Environment.GetEnvironmentVariable("Raven35Url") ?? "http://localhost:8383").TrimEnd('/');
-        protected string databaseName;
-        protected EndpointInfo endpoint = new EndpointInfo();
-
         [SetUp]
         public async Task SetupDatabase()
         {
@@ -24,53 +20,47 @@ namespace TimeoutMigrationTool.Raven3.Tests
             databaseName = $"ravendb-{testId}";
             endpoint = new EndpointInfo
             {
-                EndpointName = "A",
+                EndpointName = "A"
             };
 
             var createDbUrl = $"{ServerName}/admin/databases/{databaseName}";
 
-            using (var httpClient = new HttpClient())
-            {
-                // Create the db
-                var db = new DatabaseRecord(databaseName);
+            // Create the db
+            var db = new DatabaseRecord(databaseName);
 
-                var stringContent = new StringContent(JsonConvert.SerializeObject(db));
-                var dbCreationResult = await httpClient.PutAsync(createDbUrl, stringContent);
-                Assert.That(dbCreationResult.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-            }
+            var stringContent = new StringContent(JsonConvert.SerializeObject(db));
+            var dbCreationResult = await httpClient.PutAsync(createDbUrl, stringContent);
+            Assert.That(dbCreationResult.StatusCode, Is.EqualTo(HttpStatusCode.OK));
         }
 
         protected async Task InitTimeouts(int nrOfTimeouts, bool alternateEndpoints = false)
         {
-            using (var httpClient = new HttpClient())
+            var timeoutsPrefix = "TimeoutDatas";
+            for (var i = 0; i < nrOfTimeouts; i++)
             {
-                var timeoutsPrefix = "TimeoutDatas";
-                for (var i = 0; i < nrOfTimeouts; i++)
+                var insertTimeoutUrl = $"{ServerName}/databases/{databaseName}/docs/{timeoutsPrefix}/{i}";
+
+                // Insert the timeout data
+                var timeoutData = new TimeoutData
                 {
-                    var insertTimeoutUrl = $"{ServerName}/databases/{databaseName}/docs/{timeoutsPrefix}/{i}";
-
-                    // Insert the timeout data
-                    var timeoutData = new TimeoutData
-                    {
-                        Id = $"{timeoutsPrefix}/{i}",
-                        Destination = "WeDontCare.ThisShouldBeIgnored.BecauseItsJustForRouting",
-                        SagaId = Guid.NewGuid(),
-                        OwningTimeoutManager = "A",
-                        Time = i < nrOfTimeouts / 2 ? DateTime.Now.AddDays(7) : DateTime.Now.AddDays(14),
-                        Headers = new Dictionary<string, string>(),
-                        State = Encoding.ASCII.GetBytes("This is my state")
-                    };
-                    if (alternateEndpoints)
-                    {
-                        timeoutData.OwningTimeoutManager = i < (nrOfTimeouts / 3) ? "A" : i < (nrOfTimeouts / 3) * 2 ? "B" : "C";
-                    }
-
-                    var serializeObject = JsonConvert.SerializeObject(timeoutData);
-                    var httpContent = new StringContent(serializeObject);
-
-                    var result = await httpClient.PutAsync(insertTimeoutUrl, httpContent);
-                    Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Created));
+                    Id = $"{timeoutsPrefix}/{i}",
+                    Destination = "WeDontCare.ThisShouldBeIgnored.BecauseItsJustForRouting",
+                    SagaId = Guid.NewGuid(),
+                    OwningTimeoutManager = "A",
+                    Time = i < nrOfTimeouts / 2 ? DateTime.Now.AddDays(7) : DateTime.Now.AddDays(14),
+                    Headers = new Dictionary<string, string>(),
+                    State = Encoding.ASCII.GetBytes("This is my state")
+                };
+                if (alternateEndpoints)
+                {
+                    timeoutData.OwningTimeoutManager = i < (nrOfTimeouts / 3) ? "A" : i < (nrOfTimeouts / 3) * 2 ? "B" : "C";
                 }
+
+                var serializeObject = JsonConvert.SerializeObject(timeoutData);
+                var httpContent = new StringContent(serializeObject);
+
+                var result = await httpClient.PutAsync(insertTimeoutUrl, httpContent);
+                Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Created));
             }
         }
 
@@ -89,7 +79,7 @@ namespace TimeoutMigrationTool.Raven3.Tests
                 {ApplicationOptions.RavenServerUrl, ServerName},
                 {ApplicationOptions.RavenDatabaseName, databaseName},
                 {ApplicationOptions.RavenVersion, RavenDbVersion.ThreeDotFive.ToString()},
-                {ApplicationOptions.RavenTimeoutPrefix, RavenConstants.DefaultTimeoutPrefix},
+                {ApplicationOptions.RavenTimeoutPrefix, RavenConstants.DefaultTimeoutPrefix}
             };
 
             var toolState = new ToolState(runParameters, endpoint)
@@ -102,43 +92,39 @@ namespace TimeoutMigrationTool.Raven3.Tests
 
         protected async Task SaveToolState(ToolState toolState)
         {
-            using (var httpClient = new HttpClient())
+            var bulkInsertUrl = $"{ServerName}/databases/{databaseName}/bulk_docs";
+            var bulkCreateBatchAndUpdateTimeoutsCommand = new[]
             {
-                var bulkInsertUrl = $"{ServerName}/databases/{databaseName}/bulk_docs";
-                var bulkCreateBatchAndUpdateTimeoutsCommand = new[]
+                new
                 {
-                    new {
-                        Method = "PUT",
-                        Key = RavenConstants.ToolStateId,
-                        Document = RavenToolState.FromToolState(toolState),
-                        Metadata = new object()
-                    }
-                };
+                    Method = "PUT",
+                    Key = RavenConstants.ToolStateId,
+                    Document = RavenToolState.FromToolState(toolState),
+                    Metadata = new object()
+                }
+            };
 
-                var serializedCommands = JsonConvert.SerializeObject(bulkCreateBatchAndUpdateTimeoutsCommand);
-                var result = await httpClient
-                    .PostAsync(bulkInsertUrl, new StringContent(serializedCommands, Encoding.UTF8, "application/json"));
-                result.EnsureSuccessStatusCode();
-            }
+            var serializedCommands = JsonConvert.SerializeObject(bulkCreateBatchAndUpdateTimeoutsCommand);
+            var result = await httpClient
+                .PostAsync(bulkInsertUrl, new StringContent(serializedCommands, Encoding.UTF8, "application/json"));
+            result.EnsureSuccessStatusCode();
         }
 
         protected async Task<ToolState> GetToolState()
         {
             var url = $"{ServerName}/databases/{databaseName}/docs?id={RavenConstants.ToolStateId}";
-            using (var httpClient = new HttpClient())
+
+            var response = await httpClient.GetAsync(url);
+            if (response.StatusCode == HttpStatusCode.NotFound)
             {
-                var response = await httpClient.GetAsync(url);
-                if (response.StatusCode == HttpStatusCode.NotFound)
-                {
-                    return null;
-                }
-
-                var contentString = await response.Content.ReadAsStringAsync();
-                var ravenToolState = JsonConvert.DeserializeObject<RavenToolState>(contentString);
-                var batches = await GetBatches(ravenToolState.Batches.ToArray());
-
-                return ravenToolState.ToToolState(batches);
+                return null;
             }
+
+            var contentString = await response.Content.ReadAsStringAsync();
+            var ravenToolState = JsonConvert.DeserializeObject<RavenToolState>(contentString);
+            var batches = await GetBatches(ravenToolState.Batches.ToArray());
+
+            return ravenToolState.ToToolState(batches);
         }
 
         protected async Task<List<BatchInfo>> GetBatches(string[] ids)
@@ -148,14 +134,11 @@ namespace TimeoutMigrationTool.Raven3.Tests
             foreach (var id in ids)
             {
                 var url = $"{ServerName}/databases/{databaseName}/docs?id={id}";
-                using (var httpClient = new HttpClient())
-                {
-                    var response = await httpClient.GetAsync(url);
-                    var contentString = await response.Content.ReadAsStringAsync();
+                var response = await httpClient.GetAsync(url);
+                var contentString = await response.Content.ReadAsStringAsync();
 
-                    var batch = JsonConvert.DeserializeObject<BatchInfo>(contentString);
-                    batches.Add(batch);
-                }
+                var batch = JsonConvert.DeserializeObject<BatchInfo>(contentString);
+                batches.Add(batch);
             }
 
             return batches;
@@ -186,10 +169,12 @@ namespace TimeoutMigrationTool.Raven3.Tests
         private Task<HttpResponseMessage> DeleteDatabase()
         {
             var killDb = $"{ServerName}/admin/databases/{databaseName}";
-            using (var httpClient = new HttpClient())
-            {
-                return httpClient.DeleteAsync(killDb);
-            }
+            return httpClient.DeleteAsync(killDb);
         }
+
+        protected string ServerName = (Environment.GetEnvironmentVariable("Raven35Url") ?? "http://localhost:8383").TrimEnd('/');
+        protected string databaseName;
+        protected EndpointInfo endpoint = new EndpointInfo();
+        protected static readonly HttpClient httpClient = new HttpClient();
     }
 }

--- a/src/TimeoutMigrationTool.Raven4.Tests/RavenPreparesTheMigration.cs
+++ b/src/TimeoutMigrationTool.Raven4.Tests/RavenPreparesTheMigration.cs
@@ -1,18 +1,15 @@
-using System;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
-using NUnit.Framework;
-using Particular.TimeoutMigrationTool;
-using Particular.TimeoutMigrationTool.RavenDB;
-
 namespace TimeoutMigrationTool.Raven4.Tests
 {
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Particular.TimeoutMigrationTool;
+    using Particular.TimeoutMigrationTool.RavenDB;
+
     public class RavenPreparesTheMigration : RavenTimeoutStorageTestSuite
     {
-        private readonly int nrOfTimeouts = 1500;
-
         [SetUp]
         public async Task Setup()
         {
@@ -105,12 +102,10 @@ namespace TimeoutMigrationTool.Raven4.Tests
                 new RavenDBTimeoutStorage(ServerName, databaseName, "TimeoutDatas", RavenDbVersion.Four);
             await timeoutStorage.RemoveToolState();
 
-            using (var httpClient = new HttpClient())
-            {
-                var getStateUrl = $"{ServerName}/databases/{databaseName}/docs?id={RavenConstants.ToolStateId}";
-                var result = await httpClient.GetAsync(getStateUrl);
-                Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
-            }
+
+            var getStateUrl = $"{ServerName}/databases/{databaseName}/docs?id={RavenConstants.ToolStateId}";
+            var result = await httpClient.GetAsync(getStateUrl);
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
         [Test]
@@ -127,5 +122,7 @@ namespace TimeoutMigrationTool.Raven4.Tests
             var updatedToolState = await GetToolState();
             Assert.That(updatedToolState.Status, Is.EqualTo(MigrationStatus.StoragePrepared));
         }
+
+        private readonly int nrOfTimeouts = 1500;
     }
 }

--- a/src/TimeoutMigrationTool.Raven4.Tests/RavenTimeoutStorageTestSuite.cs
+++ b/src/TimeoutMigrationTool.Raven4.Tests/RavenTimeoutStorageTestSuite.cs
@@ -31,9 +31,6 @@ namespace TimeoutMigrationTool.Raven4.Tests
             }
         }
 
-        protected string databaseName;
-        protected EndpointInfo endpoint = new EndpointInfo();
-
         [SetUp]
         public async Task SetupDatabase()
         {
@@ -41,56 +38,50 @@ namespace TimeoutMigrationTool.Raven4.Tests
             databaseName = $"ravendb-{testId}";
             endpoint = new EndpointInfo
             {
-                EndpointName = "A",
+                EndpointName = "A"
             };
 
             var createDbUrl = $"{ServerName}/admin/databases?name={databaseName}";
 
-            using (var httpClient = new HttpClient())
+            // Create the db
+            var db = new DatabaseRecord
             {
-                // Create the db
-                var db = new DatabaseRecord
-                {
-                    Disabled = false,
-                    DatabaseName = databaseName
-                };
+                Disabled = false,
+                DatabaseName = databaseName
+            };
 
-                var stringContent = new StringContent(JsonConvert.SerializeObject(db));
-                var dbCreationResult = await httpClient.PutAsync(createDbUrl, stringContent);
-                Assert.That(dbCreationResult.StatusCode, Is.EqualTo(HttpStatusCode.Created));
-            }
+            var stringContent = new StringContent(JsonConvert.SerializeObject(db));
+            var dbCreationResult = await httpClient.PutAsync(createDbUrl, stringContent);
+            Assert.That(dbCreationResult.StatusCode, Is.EqualTo(HttpStatusCode.Created));
         }
 
         protected async Task InitTimeouts(int nrOfTimeouts, bool alternateEndpoints = false)
         {
-            using (var httpClient = new HttpClient())
+            var timeoutsPrefix = "TimeoutDatas";
+            for (var i = 0; i < nrOfTimeouts; i++)
             {
-                var timeoutsPrefix = "TimeoutDatas";
-                for (var i = 0; i < nrOfTimeouts; i++)
+                var insertTimeoutUrl = $"{ServerName}/databases/{databaseName}/docs?id={timeoutsPrefix}/{i}";
+
+                // Insert the timeout data
+                var timeoutData = new TimeoutData
                 {
-                    var insertTimeoutUrl = $"{ServerName}/databases/{databaseName}/docs?id={timeoutsPrefix}/{i}";
-
-                    // Insert the timeout data
-                    var timeoutData = new TimeoutData
-                    {
-                        Destination = "WeDontCare.ThisShouldBeIgnored.BecauseItsJustForRouting",
-                        SagaId = Guid.NewGuid(),
-                        OwningTimeoutManager = "A",
-                        Time = i < nrOfTimeouts / 2 ? DateTime.Now.AddDays(7) : DateTime.Now.AddDays(14),
-                        Headers = new Dictionary<string, string>(),
-                        State = Encoding.ASCII.GetBytes("This is my state")
-                    };
-                    if (alternateEndpoints)
-                    {
-                        timeoutData.OwningTimeoutManager = i < (nrOfTimeouts / 3) ? "A" : i < (nrOfTimeouts / 3) * 2 ? "B" : "C";
-                    }
-
-                    var serializeObject = JsonConvert.SerializeObject(timeoutData);
-                    var httpContent = new StringContent(serializeObject);
-
-                    var result = await httpClient.PutAsync(insertTimeoutUrl, httpContent);
-                    Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Created));
+                    Destination = "WeDontCare.ThisShouldBeIgnored.BecauseItsJustForRouting",
+                    SagaId = Guid.NewGuid(),
+                    OwningTimeoutManager = "A",
+                    Time = i < nrOfTimeouts / 2 ? DateTime.Now.AddDays(7) : DateTime.Now.AddDays(14),
+                    Headers = new Dictionary<string, string>(),
+                    State = Encoding.ASCII.GetBytes("This is my state")
+                };
+                if (alternateEndpoints)
+                {
+                    timeoutData.OwningTimeoutManager = i < (nrOfTimeouts / 3) ? "A" : i < (nrOfTimeouts / 3) * 2 ? "B" : "C";
                 }
+
+                var serializeObject = JsonConvert.SerializeObject(timeoutData);
+                var httpContent = new StringContent(serializeObject);
+
+                var result = await httpClient.PutAsync(insertTimeoutUrl, httpContent);
+                Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Created));
             }
         }
 
@@ -102,7 +93,7 @@ namespace TimeoutMigrationTool.Raven4.Tests
                 {ApplicationOptions.RavenServerUrl, ServerName},
                 {ApplicationOptions.RavenDatabaseName, databaseName},
                 {ApplicationOptions.RavenVersion, RavenDbVersion.Four.ToString()},
-                {ApplicationOptions.RavenTimeoutPrefix, RavenConstants.DefaultTimeoutPrefix},
+                {ApplicationOptions.RavenTimeoutPrefix, RavenConstants.DefaultTimeoutPrefix}
             };
 
             var toolState = new ToolState(runParameters, endpoint)
@@ -122,40 +113,34 @@ namespace TimeoutMigrationTool.Raven4.Tests
 
         protected async Task SaveToolState(ToolState toolState)
         {
-            using (var httpClient = new HttpClient())
-            {
-                var insertStateUrl = $"{ServerName}/databases/{databaseName}/docs?id={RavenConstants.ToolStateId}";
+            var insertStateUrl = $"{ServerName}/databases/{databaseName}/docs?id={RavenConstants.ToolStateId}";
 
-                var serializeObject = JsonConvert.SerializeObject(RavenToolState.FromToolState(toolState));
-                var httpContent = new StringContent(serializeObject);
+            var serializeObject = JsonConvert.SerializeObject(RavenToolState.FromToolState(toolState));
+            var httpContent = new StringContent(serializeObject);
 
-                var result = await httpClient.PutAsync(insertStateUrl, httpContent);
-                Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Created));
-            }
+            var result = await httpClient.PutAsync(insertStateUrl, httpContent);
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Created));
         }
 
         protected async Task<ToolState> GetToolState()
         {
             var url = $"{ServerName}/databases/{databaseName}/docs?id={RavenConstants.ToolStateId}";
-            using (var httpClient = new HttpClient())
+            var response = await httpClient.GetAsync(url);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
             {
-                var response = await httpClient.GetAsync(url);
-
-                if (response.StatusCode == HttpStatusCode.NotFound)
-                {
-                    return null;
-                }
-
-                var contentString = await response.Content.ReadAsStringAsync();
-
-                var jObject = JObject.Parse(contentString);
-                var resultSet = jObject.SelectToken("Results");
-
-                var ravenToolState = JsonConvert.DeserializeObject<RavenToolState[]>(resultSet.ToString()).Single();
-                var batches = await GetBatches(ravenToolState.Batches.ToArray());
-
-                return ravenToolState.ToToolState(batches);
+                return null;
             }
+
+            var contentString = await response.Content.ReadAsStringAsync();
+
+            var jObject = JObject.Parse(contentString);
+            var resultSet = jObject.SelectToken("Results");
+
+            var ravenToolState = JsonConvert.DeserializeObject<RavenToolState[]>(resultSet.ToString()).Single();
+            var batches = await GetBatches(ravenToolState.Batches.ToArray());
+
+            return ravenToolState.ToToolState(batches);
         }
 
         protected async Task<List<BatchInfo>> GetBatches(string[] ids)
@@ -165,17 +150,14 @@ namespace TimeoutMigrationTool.Raven4.Tests
             foreach (var id in ids)
             {
                 var url = $"{ServerName}/databases/{databaseName}/docs?id={id}";
-                using (var httpClient = new HttpClient())
-                {
-                    var response = await httpClient.GetAsync(url);
-                    var contentString = await response.Content.ReadAsStringAsync();
+                var response = await httpClient.GetAsync(url);
+                var contentString = await response.Content.ReadAsStringAsync();
 
-                    var jObject = JObject.Parse(contentString);
-                    var resultSet = jObject.SelectToken("Results");
+                var jObject = JObject.Parse(contentString);
+                var resultSet = jObject.SelectToken("Results");
 
-                    var timeout = JsonConvert.DeserializeObject<BatchInfo[]>(resultSet.ToString()).SingleOrDefault();
-                    batches.Add(timeout);
-                }
+                var timeout = JsonConvert.DeserializeObject<BatchInfo[]>(resultSet.ToString()).SingleOrDefault();
+                batches.Add(timeout);
             }
 
             return batches;
@@ -187,7 +169,7 @@ namespace TimeoutMigrationTool.Raven4.Tests
             var killDb = $"{ServerName}/admin/databases";
             var deleteDb = new DeleteDbParams
             {
-                DatabaseNames = new[] { databaseName },
+                DatabaseNames = new[] {databaseName},
                 HardDelete = true
             };
             var httpRequest = new HttpRequestMessage
@@ -197,16 +179,13 @@ namespace TimeoutMigrationTool.Raven4.Tests
                 RequestUri = new Uri(killDb)
             };
 
-            using (var httpClient = new HttpClient())
-            {
-                var killDbResult = await httpClient.SendAsync(httpRequest);
-                Assert.That(killDbResult.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-            }
+            var killDbResult = await httpClient.SendAsync(httpRequest);
+            Assert.That(killDbResult.StatusCode, Is.EqualTo(HttpStatusCode.OK));
         }
 
         protected async Task<TimeoutData> GetTimeout(string timeoutId)
         {
-            var list = await GetTimeouts(new[] { timeoutId });
+            var list = await GetTimeouts(new[] {timeoutId});
             return list.SingleOrDefault();
         }
 
@@ -217,20 +196,21 @@ namespace TimeoutMigrationTool.Raven4.Tests
             foreach (var timeoutId in timeoutIds)
             {
                 var url = $"{ServerName}/databases/{databaseName}/docs?id={timeoutId}";
-                using (var httpClient = new HttpClient())
-                {
-                    var response = await httpClient.GetAsync(url);
-                    var contentString = await response.Content.ReadAsStringAsync();
+                var response = await httpClient.GetAsync(url);
+                var contentString = await response.Content.ReadAsStringAsync();
 
-                    var jObject = JObject.Parse(contentString);
-                    var resultSet = jObject.SelectToken("Results");
+                var jObject = JObject.Parse(contentString);
+                var resultSet = jObject.SelectToken("Results");
 
-                    var timeout = JsonConvert.DeserializeObject<TimeoutData[]>(resultSet.ToString()).SingleOrDefault();
-                    timeouts.Add(timeout);
-                }
+                var timeout = JsonConvert.DeserializeObject<TimeoutData[]>(resultSet.ToString()).SingleOrDefault();
+                timeouts.Add(timeout);
             }
 
             return timeouts;
         }
+
+        protected string databaseName;
+        protected EndpointInfo endpoint = new EndpointInfo();
+        protected static readonly HttpClient httpClient = new HttpClient();
     }
 }

--- a/src/TimeoutMigrationTool/RavenDB/RavenDBTimeoutsArchiver.cs
+++ b/src/TimeoutMigrationTool/RavenDB/RavenDBTimeoutsArchiver.cs
@@ -1,13 +1,13 @@
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Particular.TimeoutMigrationTool.RavenDB.HttpCommands;
-
 namespace Particular.TimeoutMigrationTool.RavenDB
 {
+    using System.Linq;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HttpCommands;
+    using Newtonsoft.Json;
+
     class RavenDBTimeoutsArchiver
     {
         public async Task ArchiveTimeouts(string serverName, string databaseName, string[] timeoutIds, RavenDbVersion version, CancellationToken cancellationToken)
@@ -16,13 +16,11 @@ namespace Particular.TimeoutMigrationTool.RavenDB
 
             var command = GetPatchCommand(timeoutIds, version);
 
-            using (var httpClient = new HttpClient())
-            {
-                var serializedCommands = JsonConvert.SerializeObject(command);
 
-                var result = await httpClient.PostAsync(url, new StringContent(serializedCommands, Encoding.UTF8, "application/json"));
-                result.EnsureSuccessStatusCode();
-            }
+            var serializedCommands = JsonConvert.SerializeObject(command);
+
+            var result = await httpClient.PostAsync(url, new StringContent(serializedCommands, Encoding.UTF8, "application/json"));
+            result.EnsureSuccessStatusCode();
         }
 
         private static object GetPatchCommand(string[] timeoutIds, RavenDbVersion version)
@@ -38,7 +36,7 @@ namespace Particular.TimeoutMigrationTool.RavenDB
                             Id = timeoutId,
                             Type = "PATCH",
                             ChangeVector = null,
-                            Patch = new Patch()
+                            Patch = new Patch
                             {
                                 Script = $"this.OwningTimeoutManager = '{RavenConstants.MigrationOngoingPrefix}' + this.OwningTimeoutManager;",
                                 Values = new { }
@@ -55,7 +53,7 @@ namespace Particular.TimeoutMigrationTool.RavenDB
                     Key = timeoutId,
                     Method = "EVAL",
                     DebugMode = false,
-                    Patch = new Patch()
+                    Patch = new Patch
                     {
                         Script = $"this.OwningTimeoutManager = '{RavenConstants.MigrationOngoingPrefix}' + this.OwningTimeoutManager;",
                         Values = new { }
@@ -63,5 +61,7 @@ namespace Particular.TimeoutMigrationTool.RavenDB
                 };
             }).ToArray();
         }
+
+        static readonly HttpClient httpClient = new HttpClient();
     }
 }


### PR DESCRIPTION
Drive by PR, I was just curious what is going on and found something that might be worth adressing

Ideally the http client would be configurable somehow for example if RavenDB is used by a proxy but I didn't want to go too much overboard.

Very good article about HttpClient usage

https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/

see also official documentation

https://docs.microsoft.com/en-us/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client#create-and-initialize-httpclient