### PR TITLE
Adding an index to the copied timeouts to increase the performance

### DIFF
--- a/src/TimeoutMigrationTool/SqlP/MsSqlServer.cs
+++ b/src/TimeoutMigrationTool/SqlP/MsSqlServer.cs
@@ -88,6 +88,10 @@ BEGIN TRANSACTION
         PersistenceVersion VARCHAR(23) NOT NULL
     );
 
+    CREATE NONCLUSTERED INDEX INDEX_Status_BatchNumber
+    ON [dbo].['{migrationTableName}'] ([Status])
+    INCLUDE ([BatchNumber]);
+
     DELETE [{endpointName}_TimeoutData]
     OUTPUT DELETED.Id,
         -1,


### PR DESCRIPTION
By adding this index the migration runs 2 times faster (batch is migrated in 2 seconds instead of 4)