### PR TITLE
Raven prepare with index

### DIFF
--- a/src/TimeoutMigrationTool.Raven.FakeData/Program.cs
+++ b/src/TimeoutMigrationTool.Raven.FakeData/Program.cs
@@ -17,7 +17,7 @@
             var serverName = args[0];
             var databaseName = args[1];
             var ravenVersion = args[2] == "4" ? RavenDbVersion.Four : RavenDbVersion.ThreeDotFive;
-            var nrOfTimeoutsToInsert = (args.Length == 3 || string.IsNullOrEmpty(args[3])) ? 100050 : Convert.ToInt32(args[3]);
+            var nrOfTimeoutsToInsert = (args.Length == 3 || string.IsNullOrEmpty(args[3])) ? 1000000 : Convert.ToInt32(args[3]);
 
             var createDbUrl = ravenVersion == RavenDbVersion.Four ? $"{serverName}/admin/databases?name={databaseName}" : $"{serverName}/admin/databases/{databaseName}";
             var httpContent = BuildHttpContentForDbCreation(ravenVersion, databaseName);

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/IRavenTestSuite.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/IRavenTestSuite.cs
@@ -22,6 +22,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         Task<RavenToolState> GetToolState();
         Task<List<RavenBatch>> GetBatches(string[] ids);
         Task TeardownDatabase();
-        Task CreateLegacyTimeoutManagerIndex();
+        Task CreateLegacyTimeoutManagerIndex(bool waitForIndexToBeUpToDate);
+        Task EnsureIndexIsNotStale();
     }
 }

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/IRavenTestSuite.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/IRavenTestSuite.cs
@@ -22,6 +22,6 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         Task<RavenToolState> GetToolState();
         Task<List<RavenBatch>> GetBatches(string[] ids);
         Task TeardownDatabase();
-        Task CreateIndex();
+        Task CreateLegacyTimeoutManagerIndex();
     }
 }

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/Raven3/Raven3TestSuite.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/Raven3/Raven3TestSuite.cs
@@ -204,7 +204,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests.Raven3
         public string serverName = (Environment.GetEnvironmentVariable("Raven35Url") ?? "http://localhost:8383").TrimEnd('/');
         protected static readonly HttpClient httpClient = new HttpClient();
 
-        public async Task CreateIndex()
+        public async Task CreateLegacyTimeoutManagerIndex()
         {
             var map = "from doc in docs select new {  doc.Time, doc.SagaId }";
             var index = new

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/Raven4/Raven4TestSuite.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/Raven4/Raven4TestSuite.cs
@@ -75,7 +75,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests.Raven4
                 };
                 if (alternateEndpoints)
                 {
-                    timeoutData.OwningTimeoutManager = i < (nrOfTimeouts / 3) ? "A" : i < (nrOfTimeouts / 3) * 2 ? "B" : "C";
+                    timeoutData.OwningTimeoutManager = i < (nrOfTimeouts / 2) ? "A" : "B";
                 }
 
                 var serializeObject = JsonConvert.SerializeObject(timeoutData);
@@ -208,7 +208,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests.Raven4
             Assert.That(killDbResult.StatusCode, Is.EqualTo(HttpStatusCode.OK));
         }
 
-        public async Task CreateIndex()
+        public async Task CreateLegacyTimeoutManagerIndex()
         {
             var map = "from doc in docs select new {  doc.Time, doc.SagaId }";
             var index = new
@@ -236,6 +236,8 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests.Raven4
             var result = await httpClient
                 .PutAsync(createIndexUrl, new StringContent(content, Encoding.UTF8, "application/json"));
             result.EnsureSuccessStatusCode();
+
+            await EnsureIndexIsNotStale();
         }
 
         public string DatabaseName { get; private set; }
@@ -247,5 +249,10 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests.Raven4
 
         public string EndpointName { get; set; }
         protected static readonly HttpClient httpClient = new HttpClient();
+
+        static async Task EnsureIndexIsNotStale()
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
     }
 }

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenAdapterTests.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenAdapterTests.cs
@@ -139,9 +139,8 @@
         {
             var nrOfTimeouts = 500;
             await testSuite.InitTimeouts(nrOfTimeouts);
-            await testSuite.CreateIndex();
+            await testSuite.CreateLegacyTimeoutManagerIndex();
 
-            await Task.Delay(TimeSpan.FromSeconds(2));
             var result = await testSuite.RavenAdapter.GetDocumentsByIndex<TimeoutData>((doc, id) => doc.Id = id, 0, TimeSpan.Zero);
 
             Assert.That(result.Documents.Count, Is.EqualTo(500));
@@ -165,7 +164,7 @@
             var suite = new Raven3TestSuite();
             await suite.SetupDatabase();
             await suite.InitTimeouts(nrOfTimeouts);
-            await suite.CreateIndex();
+            await suite.CreateLegacyTimeoutManagerIndex();
 
             var ravenAdapter = (Raven3Adapter)suite.RavenAdapter;
             await Task.Delay(TimeSpan.FromSeconds(2));
@@ -196,7 +195,7 @@
             var suite = new Raven3TestSuite();
             await suite.SetupDatabase();
             await suite.InitTimeouts(nrOfTimeouts);
-            await suite.CreateIndex();
+            await suite.CreateLegacyTimeoutManagerIndex();
 
             var ravenAdapter = (Raven3Adapter)suite.RavenAdapter;
             await Task.Delay(TimeSpan.FromSeconds(2));

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenAdapterTests.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenAdapterTests.cs
@@ -139,8 +139,8 @@
         {
             var nrOfTimeouts = 500;
             await testSuite.InitTimeouts(nrOfTimeouts);
-            await testSuite.CreateLegacyTimeoutManagerIndex();
-
+            await testSuite.CreateLegacyTimeoutManagerIndex(true);
+           
             var result = await testSuite.RavenAdapter.GetDocumentsByIndex<TimeoutData>((doc, id) => doc.Id = id, 0, TimeSpan.Zero);
 
             Assert.That(result.Documents.Count, Is.EqualTo(500));
@@ -164,8 +164,7 @@
             var suite = new Raven3TestSuite();
             await suite.SetupDatabase();
             await suite.InitTimeouts(nrOfTimeouts);
-            await suite.CreateLegacyTimeoutManagerIndex();
-
+            
             var ravenAdapter = (Raven3Adapter)suite.RavenAdapter;
             await Task.Delay(TimeSpan.FromSeconds(2));
             var resultsPage1 = await ravenAdapter.GetDocumentsByIndex<TimeoutData>((doc, id) => doc.Id = id, 0, TimeSpan.Zero);
@@ -195,8 +194,7 @@
             var suite = new Raven3TestSuite();
             await suite.SetupDatabase();
             await suite.InitTimeouts(nrOfTimeouts);
-            await suite.CreateLegacyTimeoutManagerIndex();
-
+            
             var ravenAdapter = (Raven3Adapter)suite.RavenAdapter;
             await Task.Delay(TimeSpan.FromSeconds(2));
 

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenListEndpoints.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenListEndpoints.cs
@@ -19,7 +19,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         {
             testSuite = CreateTestSuite();
             await testSuite.SetupDatabase();
-            await testSuite.CreateIndex();
+            await testSuite.CreateLegacyTimeoutManagerIndex();
         }
 
         [TearDown]
@@ -49,7 +49,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
             var endpoints = await sut.ListEndpoints(DateTime.Now);
 
             Assert.IsNotNull(endpoints);
-            Assert.That(endpoints.Count, Is.EqualTo(3));
+            Assert.That(endpoints.Count, Is.EqualTo(2));
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
             await testSuite.InitTimeouts(nrOfTimeouts, true);
 
             var sut = new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
-            var endpoints = await sut.ListEndpoints(DateTime.Now.AddDays(8));
+            var endpoints = await sut.ListEndpoints(DateTime.Now);
 
             Assert.IsNotNull(endpoints);
             Assert.That(endpoints.Count, Is.EqualTo(2));

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenListEndpoints.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenListEndpoints.cs
@@ -19,7 +19,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         {
             testSuite = CreateTestSuite();
             await testSuite.SetupDatabase();
-            await testSuite.CreateLegacyTimeoutManagerIndex();
+            await testSuite.CreateLegacyTimeoutManagerIndex(true);
         }
 
         [TearDown]
@@ -53,7 +53,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         }
 
         [Test]
-        public async Task WhenThereTimeoutsListEndpointsRespectsTheCutoffDate()
+        public async Task WhenThereAreTimeoutsListEndpointsRespectsTheCutoffDate()
         {
             await testSuite.InitTimeouts(nrOfTimeouts, true);
 

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenPreparesTheMigration.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenPreparesTheMigration.cs
@@ -19,6 +19,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         {
             testSuite = CreateTestSuite();
             await testSuite.SetupDatabase();
+            await testSuite.CreateLegacyTimeoutManagerIndex();
         }
 
         [TearDown]
@@ -33,7 +34,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         public async Task WhenGettingTimeoutStateAndNoneIsFoundNullIsReturned()
         {
             await testSuite.InitTimeouts(nrOfTimeouts);
-            var timeoutStorage = new RavenDBTimeoutStorage(testSuite.Logger, testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
+            var timeoutStorage = new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
             var toolState = await timeoutStorage.TryLoadOngoingMigration();
 
             Assert.That(toolState, Is.Null);
@@ -45,87 +46,11 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
             await testSuite.InitTimeouts(nrOfTimeouts);
             await testSuite.SaveToolState(testSuite.SetupToolState(DateTime.Now.AddDays(-1)));
 
-            var timeoutStorage = new RavenDBTimeoutStorage(testSuite.Logger, testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
+            var timeoutStorage = new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
             var retrievedToolState = await timeoutStorage.TryLoadOngoingMigration();
 
             Assert.That(retrievedToolState, Is.Not.Null);
             Assert.That(retrievedToolState.NumberOfBatches, Is.GreaterThan(0));
-        }
-
-        [Test]
-        public async Task WhenTheStorageHasNotBeenPreparedWeWantToInitBatches()
-        {
-            nrOfTimeouts = RavenConstants.DefaultPagingSize + 5;
-            await testSuite.InitTimeouts(nrOfTimeouts);
-            var timeoutStorage =
-                new RavenDBTimeoutStorage(testSuite.Logger, testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
-
-            var startTime = DateTime.UtcNow;
-
-            var toolState = await timeoutStorage.Prepare(DateTime.Now.AddDays(-1), testSuite.EndpointName, new Dictionary<string, string>());
-
-            Assert.That(toolState.NumberOfBatches, Is.EqualTo(2));
-
-            var storedToolState = await testSuite.RavenAdapter.GetDocument<RavenToolStateDto>(RavenConstants.ToolStateId, (batch, id) => { });
-
-            Assert.That(storedToolState.NumberOfTimeouts, Is.EqualTo(nrOfTimeouts));
-            Assert.That(storedToolState.NumberOfBatches, Is.EqualTo(2));
-            Assert.That(storedToolState.Status, Is.EqualTo(MigrationStatus.StoragePrepared));
-            Assert.That(storedToolState.StartedAt, Is.GreaterThan(startTime));
-
-            var firstBatch = await toolState.TryGetNextBatch();
-            var batchData = await timeoutStorage.ReadBatch(firstBatch.Number);
-            Assert.That(batchData.Count(), Is.EqualTo(RavenConstants.DefaultPagingSize));
-
-            firstBatch.State = BatchState.Completed;
-            await timeoutStorage.MarkBatchAsCompleted(firstBatch.Number);
-
-            var nextBatch = await toolState.TryGetNextBatch();
-            var nextBatchData = await timeoutStorage.ReadBatch(nextBatch.Number);
-
-            Assert.That(nextBatchData.Count(), Is.EqualTo(nrOfTimeouts - RavenConstants.DefaultPagingSize));
-        }
-
-        [Test]
-        public async Task WhenTheStorageHasNotBeenPreparedWeWantToInitBatchesWhenMoreEndpointsAreAvailable()
-        {
-            nrOfTimeouts = 3000;
-            testSuite.EndpointName = "B";
-            await testSuite.InitTimeouts(nrOfTimeouts, true);
-
-            var timeoutStorage =
-                new RavenDBTimeoutStorage(testSuite.Logger, testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
-            var toolState = await timeoutStorage.Prepare(DateTime.Now.AddDays(-1), testSuite.EndpointName, new Dictionary<string, string>());
-
-            Assert.That(toolState.NumberOfBatches, Is.EqualTo(2));
-            var nextBatch = await toolState.TryGetNextBatch();
-            var nextBatchData = await timeoutStorage.ReadBatch(nextBatch.Number);
-            Assert.That(nextBatchData.Count(), Is.EqualTo(920));
-        }
-
-        [Test]
-        public async Task WhenPrepareDiesHalfWayThroughWeCanStillSuccessfullyPrepare()
-        {
-            nrOfTimeouts = 10;
-            await testSuite.InitTimeouts(nrOfTimeouts);
-
-            var cutoffTime = DateTime.Now.AddDays(-1);
-            var timeoutStorage =
-                new RavenDBTimeoutStorage(testSuite.Logger, testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
-            await timeoutStorage.Prepare(cutoffTime, testSuite.EndpointName, new Dictionary<string, string>());
-            await testSuite.RavenAdapter.DeleteDocument(RavenConstants.ToolStateId);
-
-            var secondBatchNrOfTimeouts = 5;
-            await testSuite.InitTimeouts(secondBatchNrOfTimeouts, false, "secondBatch");
-            var toolState = await timeoutStorage.Prepare(cutoffTime, testSuite.EndpointName, new Dictionary<string, string>());
-
-            Assert.That(toolState.NumberOfBatches, Is.EqualTo(2));
-            var firstBatch = await timeoutStorage.ReadBatch(1);
-            var secondBatch = await timeoutStorage.ReadBatch(2);
-            Assert.That(firstBatch.Count(), Is.EqualTo(10));
-            Assert.That(secondBatch.Count(), Is.EqualTo(secondBatchNrOfTimeouts));
-            Assert.That(secondBatch.All(t => t.Id.Contains("secondBatch")));
-            Assert.That(firstBatch.All(t => !t.Id.Contains("secondBatch")));
         }
 
         [Test]
@@ -136,7 +61,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
 
             var cutoffTime = DateTime.Now.AddDays(-1);
             var timeoutStorage =
-                new RavenDBTimeoutStorage(testSuite.Logger, testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
+                new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
             await timeoutStorage.Prepare(cutoffTime, testSuite.EndpointName, new Dictionary<string, string>());
             await testSuite.RavenAdapter.DeleteDocument(RavenConstants.ToolStateId);
 
@@ -157,13 +82,97 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
             await testSuite.SaveToolState(toolState);
 
             var timeoutStorage =
-                new RavenDBTimeoutStorage(testSuite.Logger, testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
+                new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, false);
 
             var updatedToolState = await timeoutStorage.TryLoadOngoingMigration();
             Assert.That(updatedToolState.EndpointName, Is.EqualTo(testSuite.EndpointName));
         }
 
-        private int nrOfTimeouts = 1500;
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task WhenTheStorageHasNotBeenPreparedWeWantToInitBatches(bool useIndex)
+        {
+            nrOfTimeouts = RavenConstants.DefaultPagingSize + 5;
+            await testSuite.InitTimeouts(nrOfTimeouts);
+            var timeoutStorage =
+                new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, useIndex);
+            var startTime = DateTime.UtcNow;
+            var toolState = await timeoutStorage.Prepare(DateTime.Now.AddDays(-1), testSuite.EndpointName, new Dictionary<string, string>());
+
+            Assert.That(toolState.NumberOfBatches, Is.EqualTo(2));
+            var storedToolState = await testSuite.RavenAdapter.GetDocument<RavenToolStateDto>(RavenConstants.ToolStateId, (batch, id) => { });
+
+            Assert.That(storedToolState.NumberOfTimeouts, Is.EqualTo(nrOfTimeouts));
+            Assert.That(storedToolState.NumberOfBatches, Is.EqualTo(2));
+            Assert.That(storedToolState.Status, Is.EqualTo(MigrationStatus.StoragePrepared));
+            Assert.That(storedToolState.StartedAt, Is.GreaterThan(startTime));
+
+            var firstBatch = await toolState.TryGetNextBatch();
+            var batchData = await timeoutStorage.ReadBatch(firstBatch.Number);
+            Assert.That(batchData.Count(), Is.EqualTo(RavenConstants.DefaultPagingSize));
+
+            firstBatch.State = BatchState.Completed;
+            await timeoutStorage.MarkBatchAsCompleted(firstBatch.Number);
+
+            var nextBatch = await toolState.TryGetNextBatch();
+            var nextBatchData = await timeoutStorage.ReadBatch(nextBatch.Number);
+
+            Assert.That(nextBatchData.Count(), Is.EqualTo(nrOfTimeouts - RavenConstants.DefaultPagingSize));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task WhenTheStorageHasNotBeenPreparedWeWantToInitBatchesWhenMoreEndpointsAreAvailable(bool useIndex)
+        {
+            nrOfTimeouts = 3000;
+            testSuite.EndpointName = "B";
+            await testSuite.InitTimeouts(nrOfTimeouts, true);
+
+            var timeoutStorage =
+                new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, useIndex);
+            var toolState = await timeoutStorage.Prepare(DateTime.Now.AddDays(-1), testSuite.EndpointName, new Dictionary<string, string>());
+
+            var batch = await toolState.TryGetNextBatch();
+            var timeoutsInBatches = new List<string>();
+            while (batch != null)
+            {
+                var batchData = await timeoutStorage.ReadBatch(batch.Number);
+                timeoutsInBatches.AddRange(batchData.Select(x => x.Id));
+                batch.State = BatchState.Completed;
+                await timeoutStorage.MarkBatchAsCompleted(batch.Number);
+                batch = await toolState.TryGetNextBatch();
+            }
+
+            Assert.That(timeoutsInBatches.Distinct().Count(), Is.EqualTo(3000/2));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task WhenPrepareDiesHalfWayThroughWeCanStillSuccessfullyPrepare(bool useIndex)
+        {
+            nrOfTimeouts = 10;
+            await testSuite.InitTimeouts(nrOfTimeouts);
+
+            var cutoffTime = DateTime.Now.AddDays(-1);
+            var timeoutStorage =
+                new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, useIndex);
+            await timeoutStorage.Prepare(cutoffTime, testSuite.EndpointName, new Dictionary<string, string>());
+            await testSuite.RavenAdapter.DeleteDocument(RavenConstants.ToolStateId);
+
+            var secondBatchNrOfTimeouts = 5;
+            await testSuite.InitTimeouts(secondBatchNrOfTimeouts, false, "secondBatch");
+            var toolState = await timeoutStorage.Prepare(cutoffTime, testSuite.EndpointName, new Dictionary<string, string>());
+
+            Assert.That(toolState.NumberOfBatches, Is.EqualTo(2));
+            var firstBatch = await timeoutStorage.ReadBatch(1);
+            var secondBatch = await timeoutStorage.ReadBatch(2);
+            Assert.That(firstBatch.Count(), Is.EqualTo(10));
+            Assert.That(secondBatch.Count(), Is.EqualTo(secondBatchNrOfTimeouts));
+            Assert.That(secondBatch.All(t => t.Id.Contains("secondBatch")));
+            Assert.That(firstBatch.All(t => !t.Id.Contains("secondBatch")));
+        }
+
+        int nrOfTimeouts = 1500;
     }
 
     [TestFixture]

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenPreparesTheMigration.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/RavenPreparesTheMigration.cs
@@ -19,7 +19,6 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         {
             testSuite = CreateTestSuite();
             await testSuite.SetupDatabase();
-            await testSuite.CreateLegacyTimeoutManagerIndex();
         }
 
         [TearDown]
@@ -94,6 +93,8 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         {
             nrOfTimeouts = RavenConstants.DefaultPagingSize + 5;
             await testSuite.InitTimeouts(nrOfTimeouts);
+            await testSuite.CreateLegacyTimeoutManagerIndex(useIndex);
+            
             var timeoutStorage =
                 new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, useIndex);
             var startTime = DateTime.UtcNow;
@@ -127,6 +128,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
             nrOfTimeouts = 3000;
             testSuite.EndpointName = "B";
             await testSuite.InitTimeouts(nrOfTimeouts, true);
+            await testSuite.CreateLegacyTimeoutManagerIndex(useIndex);
 
             var timeoutStorage =
                 new RavenDBTimeoutStorage(testSuite.Logger,testSuite.ServerName, testSuite.DatabaseName, "TimeoutDatas", testSuite.RavenVersion, useIndex);
@@ -152,6 +154,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         {
             nrOfTimeouts = 10;
             await testSuite.InitTimeouts(nrOfTimeouts);
+            await testSuite.CreateLegacyTimeoutManagerIndex(useIndex);
 
             var cutoffTime = DateTime.Now.AddDays(-1);
             var timeoutStorage =
@@ -161,6 +164,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
 
             var secondBatchNrOfTimeouts = 5;
             await testSuite.InitTimeouts(secondBatchNrOfTimeouts, false, "secondBatch");
+            await testSuite.EnsureIndexIsNotStale();
             var toolState = await timeoutStorage.Prepare(cutoffTime, testSuite.EndpointName, new Dictionary<string, string>());
 
             Assert.That(toolState.NumberOfBatches, Is.EqualTo(2));

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/TimeoutMigrationTool.Raven.IntegrationTests.csproj
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/TimeoutMigrationTool.Raven.IntegrationTests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/TimeoutMigrationTool.Raven.IntegrationTests.csproj.DotSettings
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/TimeoutMigrationTool.Raven.IntegrationTests.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">Default</s:String></wpf:ResourceDictionary>

--- a/src/TimeoutMigrationTool/Properties/launchSettings.json
+++ b/src/TimeoutMigrationTool/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "TimeoutMigrationTool": {
       "commandName": "Project",
-      "commandLineArgs": "ravendb preview -v --serverUrl http://localhost:8383 --databaseName raven-timeout-test --prefix TimeoutDatas --ravenVersion 3.5 --target amqp://guest:guest@localhost:5672"
-      //"commandLineArgs": "ravendb migrate -v --serverUrl http://localhost:8383 --databaseName raven-timeout-test --prefix TimeoutDatas --ravenVersion 3.5 --target amqp://guest:guest@localhost:5672 --allEndpoints --cutoffTime \"2020-01-01 01:01:01\""
+//      "commandLineArgs": "ravendb preview -v --serverUrl http://localhost:8383 --databaseName raven-timeout-test --prefix TimeoutDatas --ravenVersion 3.5 --target amqp://guest:guest@localhost:5672"
+      "commandLineArgs": "ravendb migrate -v --serverUrl http://localhost:8383 --databaseName raven-timeout-test --prefix TimeoutDatas --ravenVersion 3.5 --target amqp://guest:guest@localhost:5672 --allEndpoints --cutoffTime \"2020-01-01 01:01:01\" --forceUseIndex"
     }
   }
 }

--- a/src/TimeoutMigrationTool/RavenDB/Raven4Adapter.cs
+++ b/src/TimeoutMigrationTool/RavenDB/Raven4Adapter.cs
@@ -167,7 +167,7 @@ namespace Particular.TimeoutMigrationTool.RavenDB
             var resultSet = jObject.SelectToken("Results");
             var isStale = Convert.ToBoolean(jObject.SelectToken("IsStale"));
             var totalNrOfDocuments = Convert.ToInt32(jObject.SelectToken("TotalResults"));
-            var indexETag = Convert.ToString(jObject.SelectToken("IndexETag"));
+            var indexETag = Convert.ToString(jObject.SelectToken("ResultEtag"));
 
             foreach (var item in resultSet)
             {

--- a/src/TimeoutMigrationTool/RavenDB/RavenConstants.cs
+++ b/src/TimeoutMigrationTool/RavenDB/RavenConstants.cs
@@ -1,5 +1,7 @@
 namespace Particular.TimeoutMigrationTool.RavenDB
 {
+    using System;
+
     public class RavenConstants
     {
         public const string ToolStateId = "TimeoutMigrationTool/State";
@@ -12,6 +14,18 @@ namespace Particular.TimeoutMigrationTool.RavenDB
         public const string MigrationDonePrefix = "__migrated__";
         public const string DefaultTimeoutPrefix  = "TimeoutDatas";
         public const string BatchPrefix = "batch";
-        public const int MaxNrOfTimeoutsWithoutIndex = 100000;
+
+        public static int GetMaxNrOfTimeoutsWithoutIndexByRavenVersion(RavenDbVersion version)
+        {
+            switch (version)
+            {
+                case RavenDbVersion.ThreeDotFive:
+                    return 100000;
+                case RavenDbVersion.Four:
+                    return 1000000;
+                default:
+                    throw new ArgumentOutOfRangeException("Unsupported version of RavenDB");
+            }
+        }
     }
 }

--- a/src/TimeoutMigrationTool/RavenDB/RavenDBTimeoutStorage.cs
+++ b/src/TimeoutMigrationTool/RavenDB/RavenDBTimeoutStorage.cs
@@ -181,7 +181,7 @@ namespace Particular.TimeoutMigrationTool.RavenDB
 
         async Task<int> GuardAgainstTooManyTimeoutsWithoutIndexUsage()
         {
-            var nrOfTimeoutsResult = await ravenAdapter.GetDocumentsByIndex<TimeoutData>((doc, id) => doc.Id = id, 0, TimeSpan.FromSeconds(5));
+            var nrOfTimeoutsResult = await ravenAdapter.GetDocumentsByIndex<TimeoutData>((doc, id) => doc.Id = id, 0, TimeSpan.FromSeconds(0));
             if (nrOfTimeoutsResult.NrOfDocuments > RavenConstants.GetMaxNrOfTimeoutsWithoutIndexByRavenVersion(ravenVersion) && !useIndex)
             {
                 throw new Exception($"We've encountered around {nrOfTimeoutsResult.NrOfDocuments} timeouts to process. Given the amount of timeouts to migrate, please shut down your endpoints before migrating and use the --{ApplicationOptions.ForceUseIndex} option.");


### PR DESCRIPTION
Final bulk test results with index for 1m timeouts:
- Preview: 8m
- Full prepare (includes Preview): 30m
- Full migration: 1h1m