### PR TITLE
Fixing recovering of a batch

### DIFF
--- a/src/TimeoutMigrationTool/ConsoleLogger.cs
+++ b/src/TimeoutMigrationTool/ConsoleLogger.cs
@@ -30,7 +30,7 @@
 
             if(verbose)
             {
-                logStatment = $"{DateTime.UtcNow}: {logStatment}";
+                logStatment = $"{DateTime.UtcNow}: {logLevel} {logStatment}";
             }
 
             Console.WriteLine(logStatment);


### PR DESCRIPTION
- Adding log level to the logger
- Adding an if to recognize that the batch is being recovered and to not check if the count of messages pushed does not match the batch.Count