### PR TITLE
Lock lang version to 8

### DIFF
--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/TimeoutMigrationTool.Raven.IntegrationTests.csproj
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/TimeoutMigrationTool.Raven.IntegrationTests.csproj
@@ -5,7 +5,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TimeoutMigrationTool.SqlP.FakeData/TimeoutMigrationTool.SqlP.FakeData.csproj
+++ b/src/TimeoutMigrationTool.SqlP.FakeData/TimeoutMigrationTool.SqlP.FakeData.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="5.0.0" />
 	<PackageReference Include="NServiceBus.Transport.Msmq" Version="1.0.0" />
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/src/TimeoutMigrationTool/TimeoutMigrationTool.csproj
+++ b/src/TimeoutMigrationTool/TimeoutMigrationTool.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Since `latest` is dangerous since it can roll forwards to unsupported versions https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version#defaults