### PR TITLE
Preview command miscalculated total number of timeouts per endpoint for RavenDB

### DIFF
--- a/src/TimeoutMigrationTool.Raven.FakeData/Program.cs
+++ b/src/TimeoutMigrationTool.Raven.FakeData/Program.cs
@@ -17,11 +17,11 @@
             var serverName = args[0];
             var databaseName = args[1];
             var ravenVersion = args[2] == "4" ? RavenDbVersion.Four : RavenDbVersion.ThreeDotFive;
-            var nrOfTimeoutsToInsert = (args.Length == 3 || string.IsNullOrEmpty(args[3])) ? 300 : Convert.ToInt32(args[3]);
+            var nrOfTimeoutsToInsert = (args.Length == 3 || string.IsNullOrEmpty(args[3])) ? 1000 : Convert.ToInt32(args[3]);
 
             var createDbUrl = ravenVersion == RavenDbVersion.Four ? $"{serverName}/admin/databases?name={databaseName}" : $"{serverName}/admin/databases/{databaseName}";
             var httpContent = BuildHttpContentForDbCreation(ravenVersion, databaseName);
-
+            
             var dbCreationResult = await httpClient.PutAsync(createDbUrl, httpContent);
             if (!dbCreationResult.IsSuccessStatusCode)
             {
@@ -41,8 +41,7 @@
         static async Task<int> InitTimeouts(decimal nrOfBatches, string serverName, string databaseName, int nrOfTimeoutsToInsert, string timeoutsPrefix, RavenDbVersion ravenVersion)
         {
             var timeoutIdCounter = 0;
-
-
+            
             for (var i = 1; i <= nrOfBatches; i++) // batch inserts per paging size
             {
                 var commands = new List<object>();

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/IRavenTestSuite.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/IRavenTestSuite.cs
@@ -15,7 +15,7 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         RavenDbVersion RavenVersion { get; }
         string EndpointName { get; set; }
         Task SetupDatabase();
-        Task InitTimeouts(int nrOfTimeouts, bool alternateEndpoints = false, string prefixIdsWith = null);
+        Task InitTimeouts(int nrOfTimeouts);
         RavenToolState SetupToolState(DateTime cutoffTime);
         Task<List<RavenBatch>> SetupExistingBatchInfoInDatabase();
         Task SaveToolState(RavenToolState toolState);
@@ -24,5 +24,6 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests
         Task TeardownDatabase();
         Task CreateLegacyTimeoutManagerIndex(bool waitForIndexToBeUpToDate);
         Task EnsureIndexIsNotStale();
+        Task InitTimeouts(int nrOfTimeouts, string endpointName, int startFromId);
     }
 }

--- a/src/TimeoutMigrationTool.Raven.IntegrationTests/Raven3/Raven3TestSuite.cs
+++ b/src/TimeoutMigrationTool.Raven.IntegrationTests/Raven3/Raven3TestSuite.cs
@@ -40,13 +40,12 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests.Raven3
             Assert.That(dbCreationResult.StatusCode, Is.EqualTo(HttpStatusCode.OK));
         }
 
-        public async Task InitTimeouts(int nrOfTimeouts, bool alternateEndpoints = false, string prefixIdsWith = null)
+        public async Task InitTimeouts(int nrOfTimeouts)
         {
             var timeoutsPrefix = "TimeoutDatas";
             for (var i = 0; i < nrOfTimeouts; i++)
             {
-                var idPrefix = string.IsNullOrEmpty(prefixIdsWith) ? "" : prefixIdsWith;
-                var insertTimeoutUrl = $"{serverName}/databases/{DatabaseName}/docs/{timeoutsPrefix}/{idPrefix +i}";
+               var insertTimeoutUrl = $"{serverName}/databases/{DatabaseName}/docs/{timeoutsPrefix}/{i}";
 
                 // Insert the timeout data
                 var timeoutData = new TimeoutData
@@ -59,11 +58,34 @@ namespace TimeoutMigrationTool.Raven.IntegrationTests.Raven3
                     Headers = new Dictionary<string, string>(),
                     State = Encoding.ASCII.GetBytes("This is my state")
                 };
-                if (alternateEndpoints)
-                {
-                    timeoutData.OwningTimeoutManager = i < (nrOfTimeouts / 2) ? "A" : "B";
-                }
 
+                var serializeObject = JsonConvert.SerializeObject(timeoutData);
+                var httpContent = new StringContent(serializeObject);
+
+                var result = await httpClient.PutAsync(insertTimeoutUrl, httpContent);
+                Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Created));
+            }
+        }
+        
+        public async Task InitTimeouts(int nrOfTimeouts, string endpointName, int startFromId)
+        {
+            var timeoutsPrefix = "TimeoutDatas";
+            for (var i = 0; i < nrOfTimeouts; i++)
+            {
+                var insertTimeoutUrl = $"{serverName}/databases/{DatabaseName}/docs/{timeoutsPrefix}/{startFromId +i}";
+
+                // Insert the timeout data
+                var timeoutData = new TimeoutData
+                {
+                    Id = $"{timeoutsPrefix}/{i}",
+                    Destination = "WeDontCare.ThisShouldBeIgnored.BecauseItsJustForRouting",
+                    SagaId = Guid.NewGuid(),
+                    OwningTimeoutManager = endpointName,
+                    Time = i < nrOfTimeouts / 2 ? DateTime.Now.AddDays(7) : DateTime.Now.AddDays(14),
+                    Headers = new Dictionary<string, string>(),
+                    State = Encoding.ASCII.GetBytes("This is my state")
+                };
+                
                 var serializeObject = JsonConvert.SerializeObject(timeoutData);
                 var httpContent = new StringContent(serializeObject);
 

--- a/src/TimeoutMigrationTool/RavenDB/RavenDBTimeoutStorage.cs
+++ b/src/TimeoutMigrationTool/RavenDB/RavenDBTimeoutStorage.cs
@@ -151,10 +151,10 @@ namespace Particular.TimeoutMigrationTool.RavenDB
             var endpointsFetched = eligibleTimeouts.GroupBy(
                 key => key.OwningTimeoutManager.Replace(RavenConstants.MigrationDonePrefix, "").Replace(RavenConstants.MigrationOngoingPrefix, ""),
                 elements => elements,
-                (owningTimeoutManager, destinationTimeouts) => new EndpointInfo
+                (endpointName, destinationTimeouts) => new EndpointInfo
                 {
-                    EndpointName = owningTimeoutManager,
-                    NrOfTimeouts = eligibleTimeouts.Count(),
+                    EndpointName = endpointName,
+                    NrOfTimeouts = eligibleTimeouts.Count(x => x.OwningTimeoutManager.Replace(RavenConstants.MigrationDonePrefix, "").Replace(RavenConstants.MigrationOngoingPrefix, "") == endpointName),
                     ShortestTimeout = eligibleTimeouts.Min(x => x.Time),
                     LongestTimeout = eligibleTimeouts.Max(x => x.Time),
                     Destinations = eligibleTimeouts.GroupBy(x => x.Destination).Select(g => g.Key).ToList()


### PR DESCRIPTION
### Symptoms

The total number of timeouts per endpoint listed when running the preview command incorrectly show the total number of timeouts detected in the storage

### Who's affected

Everyone using the preview command with RavenDB as a persistence source

### Root cause

The number of timeouts was being calculating by probing the number of documents using an index, which didn't take into account the endpoint.