### PR TITLE
Timeout expirations are cut in half when migrating to RabbitMQ

### DIFF
--- a/src/TimeoutMigrationTool.RabbitMq.IntegrationTests/When_calculating_a_routing_key.cs
+++ b/src/TimeoutMigrationTool.RabbitMq.IntegrationTests/When_calculating_a_routing_key.cs
@@ -1,0 +1,29 @@
+﻿namespace TimeoutMigrationTool.RabbitMq.IntegrationTests
+{
+    using NUnit.Framework;
+    using Particular.TimeoutMigrationTool.RabbitMq;
+
+    [TestFixture]
+    public class When_calculating_a_routing_key
+    {
+        [TestCase(0, "some-address", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.some-address", 0)]
+        [TestCase(10, "some-address", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.some-address", 3)]
+        [TestCase(RabbitMqTimeoutTarget.MaxDelayInSeconds, "some-address", "1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.some-address", 27)]
+        public void Should_return_correct_routing_key_based_on_delay(int delayInSeconds, string address, string expectedRoutingKey, int expectedStartingDelayLevel)
+        {
+            var result = RabbitBatchWriter.CalculateRoutingKey(delayInSeconds, address, out var startingDelayLevel);
+
+            Assert.That(result, Is.EqualTo(expectedRoutingKey));
+            Assert.That(startingDelayLevel, Is.EqualTo(expectedStartingDelayLevel));
+        }
+
+        [Test]
+        public void Should_return_routing_key_with_delay_zero_seconds_for_negative_delay()
+        {
+            var result = RabbitBatchWriter.CalculateRoutingKey(-123, "some-address", out var startingDelayLevel);
+
+            Assert.That(result, Is.EqualTo("0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.some-address"));
+            Assert.That(startingDelayLevel, Is.EqualTo(0));
+        }
+    }
+}

--- a/src/TimeoutMigrationTool/RabbitMq/RabbitBatchWriter.cs
+++ b/src/TimeoutMigrationTool/RabbitMq/RabbitBatchWriter.cs
@@ -9,7 +9,7 @@
     using Microsoft.Extensions.Logging;
     using RabbitMQ.Client;
 
-    class RabbitBatchWriter
+    public class RabbitBatchWriter
     {
         public RabbitBatchWriter(ILogger logger, string rabbitConnectionString)
         {
@@ -132,7 +132,7 @@
             }
         }
 
-        static string CalculateRoutingKey(int delayInSeconds, string address, out int startingDelayLevel)
+        public static string CalculateRoutingKey(int delayInSeconds, string address, out int startingDelayLevel)
         {
             if (delayInSeconds < 0)
             {

--- a/src/TimeoutMigrationTool/RabbitMq/RabbitMqTimeoutTarget.cs
+++ b/src/TimeoutMigrationTool/RabbitMq/RabbitMqTimeoutTarget.cs
@@ -155,8 +155,9 @@
         readonly ILogger logger;
         readonly RabbitBatchWriter batchWriter;
 
-        const int MaxDelayInSeconds = (1 << MaxLevel) - 1;
+        const int maxNumberOfBitsToUse = 28;
 
-        public const int MaxLevel = 28;
+        public const int MaxDelayInSeconds = (1 << maxNumberOfBitsToUse) - 1;
+        public const int MaxLevel = maxNumberOfBitsToUse - 1;
     }
 }


### PR DESCRIPTION
Backport of fix for #265 for the release-1.2 branch.