### PR TITLE
Make dependabot ignore NServiceBus.RavenDb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,7 @@ updates:
     - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
     # GitVersion updates need to be manually tested and verified before updating to a newer version
     - dependency-name: "GitVersion.MsBuild"
-    - dependency-name: "NServiceBus.RavenDB"
-    - dependency-name: "NServiceBus.RavenDB"    
+    - dependency-name: "NServiceBus.RavenDB"   
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
     # GitVersion updates need to be manually tested and verified before updating to a newer version
     - dependency-name: "GitVersion.MsBuild"
+    - dependency-name: "NServiceBus.RavenDB"
+    - dependency-name: "NServiceBus.RavenDB"    
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.reposync.yml
+++ b/.reposync.yml
@@ -1,1 +1,2 @@
-
+exclusions:
+  - .github/dependabot.yml


### PR DESCRIPTION
TimeoutMigrationTool targets specific versions of RavenDB and they should not be bumped.