### PR TITLE
Add SqlTransport Source and Add Azure Service Bus Target

### DIFF
--- a/src/TimeoutMigrationTool/ASB/AsbConstants.cs
+++ b/src/TimeoutMigrationTool/ASB/AsbConstants.cs
@@ -1,0 +1,9 @@
+namespace Particular.TimeoutMigrationTool.ASB
+{
+    public class AsbConstants
+    {
+        public const string MigrationQueue = "timeouts-staging";
+        public const string NServicebusMigrationDestination = "NServiceBus.Migration.Destination";
+        public const string NServicebusMigrationScheduledTime = "NServiceBus.Migration.ScheduledTime";
+    }
+}

--- a/src/TimeoutMigrationTool/ASB/AsbEndpointMigrator.cs
+++ b/src/TimeoutMigrationTool/ASB/AsbEndpointMigrator.cs
@@ -1,0 +1,89 @@
+namespace Particular.TimeoutMigrationTool.ASB
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Azure.Messaging.ServiceBus;
+    using Microsoft.Extensions.Logging;
+
+    public class AsbEndpointMigrator : ITimeoutsTarget.IEndpointTargetBatchMigrator
+    {
+        readonly IAzureServiceBusEndpoint _azureServiceBusEndpoint;
+        string _queueName;
+        readonly ILogger logger;
+
+        public AsbEndpointMigrator(IAzureServiceBusEndpoint azureServiceBusEndpoint, string queueName, ILogger logger)
+        {
+            _azureServiceBusEndpoint = azureServiceBusEndpoint;
+            _queueName = queueName;
+            this.logger = logger;
+            this.logger.LogInformation($"Creating Migration for {queueName}");
+        }
+
+        public ValueTask DisposeAsync() => new ValueTask(Task.CompletedTask);
+
+        public async ValueTask<int> StageBatch(IReadOnlyList<TimeoutData> timeouts, int batchNumber)
+        {
+            logger.LogInformation($"Staging Migration for {_queueName}");
+            var messageChunks = timeouts.Select(s => MapServiceBusMessage(s)).Chunk(100);
+            foreach (var messageChunk in messageChunks)
+            {
+                await _azureServiceBusEndpoint.SendMessages(AsbConstants.MigrationQueue, messageChunk);
+            }
+            return messageChunks.Sum(s => s.Length);
+        }
+
+        public async ValueTask<int> CompleteBatch(int batchNumber)
+        {
+            logger.LogInformation($"Completing Migration for {_queueName}");
+
+            var counter = 0;
+            await _azureServiceBusEndpoint.ProcessMessages(AsbConstants.MigrationQueue, async (receivedMessage) =>
+            {
+                var scheduledTime = (DateTime)receivedMessage.ApplicationProperties[AsbConstants.NServicebusMigrationScheduledTime];
+                var messageToSend = new ServiceBusMessage()
+                {
+                    MessageId = Guid.NewGuid().ToString(),
+                    CorrelationId = receivedMessage.CorrelationId,
+                    ContentType = receivedMessage.ContentType,
+                    Body = receivedMessage.Body
+                };
+                foreach (var appProp in receivedMessage.ApplicationProperties)
+                {
+                    messageToSend.ApplicationProperties.Add(appProp.Key, appProp.Value);
+                }
+
+                if (scheduledTime < DateTime.Now)
+                {
+                    scheduledTime = DateTime.Now.AddDays(1);
+                }
+
+                counter++;
+                await _azureServiceBusEndpoint.ScheduleMessage(_queueName, scheduledTime, messageToSend);
+            });
+            return counter;
+        }
+
+        ServiceBusMessage MapServiceBusMessage(TimeoutData timeoutData)
+        {
+            var serviceBusMessage = new ServiceBusMessage
+            {
+                MessageId = Guid.NewGuid().ToString(),
+                CorrelationId = timeoutData.Id,
+                ContentType = "application/json",
+                Body = new BinaryData(timeoutData.State)
+            };
+
+            foreach (var header in timeoutData.Headers)
+            {
+                serviceBusMessage.ApplicationProperties.Add(header.Key, header.Value);
+            }
+
+            serviceBusMessage.ApplicationProperties.Add(AsbConstants.NServicebusMigrationDestination, _queueName);
+            serviceBusMessage.ApplicationProperties.Add(AsbConstants.NServicebusMigrationScheduledTime, timeoutData.Time);
+
+            return serviceBusMessage;
+        }
+    }
+}

--- a/src/TimeoutMigrationTool/ASB/AsbTarget.cs
+++ b/src/TimeoutMigrationTool/ASB/AsbTarget.cs
@@ -24,12 +24,7 @@ namespace Particular.TimeoutMigrationTool.ASB
             try
             {
                 await EnsureQueueExists(AsbConstants.MigrationQueue);
-              //  await EnsureQueueExists(endpoint.EndpointName);
                 var result = await _azureServiceBusEndpoint.GetQueueAsync(endpoint.EndpointName);
-                //if (result.Status == EntityStatus.Active)
-                //{
-                //    return migrationsResult;
-                //}
             }
             catch (Exception)
             {

--- a/src/TimeoutMigrationTool/ASB/AsbTarget.cs
+++ b/src/TimeoutMigrationTool/ASB/AsbTarget.cs
@@ -1,0 +1,62 @@
+namespace Particular.TimeoutMigrationTool.ASB
+{
+    using System;
+    using System.Threading.Tasks;
+    using Azure.Messaging.ServiceBus.Administration;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+
+    public class AsbTarget : ITimeoutsTarget
+    {
+        readonly IAzureServiceBusEndpoint _azureServiceBusEndpoint;
+        readonly ILogger logger;
+
+        public AsbTarget(IAzureServiceBusEndpoint azureServiceBusEndpoint, ILogger logger)
+        {
+            _azureServiceBusEndpoint = azureServiceBusEndpoint;
+            this.logger = logger;
+        }
+
+        public async ValueTask<MigrationCheckResult> AbleToMigrate(EndpointInfo endpoint)
+        {
+            var migrationsResult = new MigrationCheckResult();
+
+            try
+            {
+                await EnsureQueueExists(AsbConstants.MigrationQueue);
+              //  await EnsureQueueExists(endpoint.EndpointName);
+                var result = await _azureServiceBusEndpoint.GetQueueAsync(endpoint.EndpointName);
+                //if (result.Status == EntityStatus.Active)
+                //{
+                //    return migrationsResult;
+                //}
+            }
+            catch (Exception)
+            {
+                migrationsResult.Problems.Add($"Can not connect to queueName '{endpoint.EndpointName}' on connection ");
+            }
+
+            return migrationsResult;
+        }
+
+        async Task EnsureQueueExists(string queueName)
+        {
+            if (!await _azureServiceBusEndpoint.QueueExistsAsync(queueName))
+            {
+                await _azureServiceBusEndpoint.CreateQueueAsync(queueName);
+            }
+        }
+
+        public ValueTask<ITimeoutsTarget.IEndpointTargetBatchMigrator> PrepareTargetEndpointBatchMigrator(string endpointName)
+        {
+            return new ValueTask<ITimeoutsTarget.IEndpointTargetBatchMigrator>(new AsbEndpointMigrator(_azureServiceBusEndpoint, endpointName, logger));
+        }
+
+        public ValueTask Abort(string endpointName)
+        {
+            return new ValueTask();
+        }
+
+        public ValueTask Complete(string endpointName) => new ValueTask(Task.CompletedTask);
+    }
+}

--- a/src/TimeoutMigrationTool/ASB/AzureServiceBusEndpoint.cs
+++ b/src/TimeoutMigrationTool/ASB/AzureServiceBusEndpoint.cs
@@ -1,0 +1,123 @@
+namespace Particular.TimeoutMigrationTool.ASB
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Azure.Messaging.ServiceBus;
+    using Azure.Messaging.ServiceBus.Administration;
+    using Microsoft.Extensions.Logging;
+
+    public interface IAzureServiceBusEndpoint
+    {
+        Task<QueueProperties> GetQueueAsync(string queueName);
+
+        Task<bool> QueueExistsAsync(string queueName);
+
+        Task<QueueProperties> CreateQueueAsync(string queueName);
+
+        Task SendMessage(string queue, ServiceBusMessage message);
+
+        Task SendMessages(string queue, IEnumerable<ServiceBusMessage> messages);
+
+        Task<long> ScheduleMessage(string queue, DateTime datetime, ServiceBusMessage message);
+        Task ProcessMessages(string queue, Func<ServiceBusReceivedMessage, Task> processMessage, int batchCount = 50);
+
+    }
+
+    public class AzureServiceBusEndpoint : IAzureServiceBusEndpoint
+    {
+        readonly string _connectionString;
+        readonly ILogger _logger;
+
+        public AzureServiceBusEndpoint(string connectionString, ILogger logger)
+        {
+            _connectionString = connectionString;
+            _logger = logger;
+        }
+
+        public async Task<QueueProperties> GetQueueAsync(string queueName)
+        {
+            var client = new ServiceBusAdministrationClient(_connectionString);
+            var result = await client.GetQueueAsync(queueName);
+            return result.Value;
+        }
+
+        public async Task<bool> QueueExistsAsync(string queueName)
+        {
+            var client = new ServiceBusAdministrationClient(_connectionString);
+            var result = await client.QueueExistsAsync(queueName);
+            return result.Value;
+        }
+
+        public async Task<QueueProperties> CreateQueueAsync(string queueName)
+        {
+            _logger.LogInformation($"Creating queue {queueName}");
+            var client = new ServiceBusAdministrationClient(_connectionString);
+            var options = new CreateQueueOptions(queueName)
+            {
+                LockDuration = TimeSpan.FromSeconds(60)
+            };
+            var result = await client.CreateQueueAsync(options);
+            return result.Value;
+        }
+
+        public async Task SendMessage(string queue, ServiceBusMessage message)
+        {
+            var client = GetOrCreateServiceBusClient();
+            await client.CreateSender(queue).SendMessageAsync(message);
+        }
+
+        public async Task SendMessages(string queue, IEnumerable<ServiceBusMessage> messages)
+        {
+            _logger.LogInformation($"{DateTime.UtcNow}: Sending {messages.Count()} to queue {queue}");
+            var client = GetOrCreateServiceBusClient();
+            await client.CreateSender(queue).SendMessagesAsync(messages);
+        }
+
+        public async Task<long> ScheduleMessage(string queue, DateTime datetime, ServiceBusMessage message)
+        {
+            return await GetOrCreateSender(queue)
+                .ScheduleMessageAsync(message, datetime);
+        }
+
+        public async Task ProcessMessages(string queue, Func<ServiceBusReceivedMessage, Task> processMessage, int batchCount = 50)
+        {
+            var client = GetOrCreateServiceBusClient();
+            var options = new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.PeekLock };
+            var receiver = client.CreateReceiver(queue, options);
+            bool hasMessages = true;
+            while (hasMessages)
+            {
+                var messages = await receiver.ReceiveMessagesAsync(batchCount, TimeSpan.FromSeconds(30));
+                hasMessages = messages.Count > 0;
+                _logger.LogInformation($"{DateTime.UtcNow}: Received {messages.Count} messages from batch, now processing them . . . ");
+                foreach (var receivedMessage in messages)
+                {
+                    await processMessage(receivedMessage);
+                    //  _logger.LogInformation($"{DateTime.UtcNow}: Processed a message from the batch");
+                    await receiver.CompleteMessageAsync(receivedMessage);
+                    //  _logger.LogInformation($"{DateTime.UtcNow}: Completed a message from the batch");
+                }
+            }
+        }
+
+        ServiceBusClient _servicebusClient;
+        ServiceBusClient GetOrCreateServiceBusClient()
+        {
+            _servicebusClient ??= new ServiceBusClient(_connectionString);
+
+            return _servicebusClient;
+        }
+
+        Dictionary<string, ServiceBusSender> _senders = new Dictionary<string, ServiceBusSender>();
+        ServiceBusSender GetOrCreateSender(string queue)
+        {
+            if (!_senders.ContainsKey(queue))
+            {
+                _senders[queue] = GetOrCreateServiceBusClient().CreateSender(queue);
+            }
+            return _senders[queue];
+        }
+    }
+}

--- a/src/TimeoutMigrationTool/ApplicationOptions.cs
+++ b/src/TimeoutMigrationTool/ApplicationOptions.cs
@@ -7,6 +7,7 @@ namespace Particular.TimeoutMigrationTool
         public const string RavenVersion = "ravenVersion";
         public const string ForceUseIndex = "forceUseIndex";
         public const string RavenTimeoutPrefix = "prefix";
+
         public const string CutoffTime = "cutoffTime";
         public const string RabbitMqTargetConnectionString = "target";
         public const string MsmqSqlTargetConnectionString = "target";
@@ -26,5 +27,6 @@ namespace Particular.TimeoutMigrationTool
         public const string NHibernateSourceDialect = "dialect";
         public const string AsqTargetConnectionString = "target";
         public const string AsqDelayedDeliveryTableName = "delayedtablename";
+        public const string AsbTargetConnectionString = "target";
     }
 }

--- a/src/TimeoutMigrationTool/Program.cs
+++ b/src/TimeoutMigrationTool/Program.cs
@@ -2213,6 +2213,37 @@
                         });
                     });
                 });
+
+                abortCommand.Command("sqls", sqlsCommand =>
+                {
+                    sqlsCommand.OnExecute(() =>
+                    {
+                        Console.WriteLine("Specify a target with the required options.");
+                        sqlsCommand.ShowHelp();
+                        return 1;
+                    });
+                    sqlsCommand.AddOption(sourceSqlsConnectionString);
+
+                    sqlsCommand.Command("noop", sqlsToNoopCommand =>
+                    {
+
+                        sqlsToNoopCommand.OnExecuteAsync(async ct =>
+                        {
+                            var logger = new ConsoleLogger(verboseOption.HasValue());
+
+                            var sourceConnectionString = sourceSqlsConnectionString.Value();
+
+                            var cutoffTime = GetCutoffTime(cutoffTimeOption);
+
+                            var timeoutsSource = new SqlTransportSource(logger, sourceConnectionString, 100);
+                            var timeoutsTarget = new NoOpTarget();
+
+                            var runner = new AbortRunner(logger, timeoutsSource, timeoutsTarget);
+                            await runner.Run();
+                        });
+                    });
+
+                });
             });
 
             app.HelpOption(true);

--- a/src/TimeoutMigrationTool/SqlT/SqlConstants.cs
+++ b/src/TimeoutMigrationTool/SqlT/SqlConstants.cs
@@ -124,11 +124,10 @@ EXEC sp_releaseapplock @Resource = '{0}_lock'";
             return $@"
 BEGIN TRANSACTION
     DELETE [{migrationTableName}]
-        OUTPUT DELETED.Id,
-            DELETED.Destination,
+        OUTPUT 
+            DELETED.Headers,
             DELETED.State,
-            DELETED.Time,
-            DELETED.Headers
+            DELETED.Time
     INTO [{endpointName}.Delayed]
     WHERE [{migrationTableName}].Status <> 2;
 

--- a/src/TimeoutMigrationTool/SqlT/SqlTToolState.cs
+++ b/src/TimeoutMigrationTool/SqlT/SqlTToolState.cs
@@ -1,0 +1,56 @@
+﻿namespace Particular.TimeoutMigrationTool.SqlP
+{
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Threading.Tasks;
+    using Microsoft.Data.SqlClient;
+    using Particular.TimeoutMigrationTool.SqlT;
+
+    public class SqlTToolState : IToolState
+    {
+        public SqlTToolState(
+            SqlConnection connection,
+            string migrationRunId,
+            IDictionary<string, string> runParameters,
+            string endpointName,
+            int numberOfBatches,
+            MigrationStatus migrationStatus)
+        {
+            this.connection = connection;
+            this.migrationRunId = migrationRunId;
+            RunParameters = runParameters;
+            EndpointName = endpointName;
+            NumberOfBatches = numberOfBatches;
+            Status = migrationStatus;
+        }
+
+        public IDictionary<string, string> RunParameters { get; }
+        public MigrationStatus Status { get; }
+
+        public string EndpointName { get; }
+
+        public int NumberOfBatches { get; }
+
+        public async Task<BatchInfo> TryGetNextBatch()
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = SqlConstants.GetNextBatch(migrationRunId);
+
+            await using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+            if (!await reader.ReadAsync())
+            {
+                return null;
+            }
+
+            return new BatchInfo(reader.GetInt32(0), GetBatchStatus(reader.GetInt32(1)), reader.GetInt32(2));
+        }
+
+        BatchState GetBatchStatus(int dbStatus)
+        {
+            return (BatchState)dbStatus;
+        }
+
+        readonly SqlConnection connection;
+        readonly string migrationRunId;
+    }
+}

--- a/src/TimeoutMigrationTool/SqlT/SqlTransportSource.cs
+++ b/src/TimeoutMigrationTool/SqlT/SqlTransportSource.cs
@@ -4,15 +4,11 @@
     using System.Collections.Generic;
     using System.Data;
     using System.Data.Common;
-    using System.Linq;
-    using System.Text;
     using System.Threading.Tasks;
-    using global::NHibernate.Dialect;
     using Microsoft.Data.SqlClient;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Particular.TimeoutMigrationTool.SqlP;
-    using RabbitMQ.Client;
 
     class SqlTransportSource : ITimeoutsSource
     {
@@ -27,7 +23,7 @@
         {
             this.logger = logger;
             this.batchSize = batchSize;
-            this.connection = new SqlConnection(connectionString);
+            connection = new SqlConnection(connectionString);
         }
 
         public async Task Abort()
@@ -70,6 +66,7 @@
             command.CommandText = SqlConstants.MarkMigrationAsCompleted;
 
             await command.ExecuteNonQueryAsync();
+            logger.LogInformation("Migration Completed");
         }
         public async Task<IReadOnlyList<EndpointInfo>> ListEndpoints(DateTime cutOffTime)
         {
@@ -235,10 +232,10 @@
                 throw new Exception("Multiple uncompleted migrations found");
             }
 
-            return new SqlTToolState(this.connection, migrationRunId, runParameters, endpoint, numberOfBatches, status);
+            return new SqlTToolState(connection, migrationRunId, runParameters, endpoint, numberOfBatches, status);
         }
 
-        private async ValueTask EnsureConnectionOpen()
+        async ValueTask EnsureConnectionOpen()
         {
             if (connection.State != ConnectionState.Open)
             {

--- a/src/TimeoutMigrationTool/SqlT/SqlTransportSource.cs
+++ b/src/TimeoutMigrationTool/SqlT/SqlTransportSource.cs
@@ -1,0 +1,298 @@
+﻿namespace Particular.TimeoutMigrationTool.SqlT
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Data.Common;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using global::NHibernate.Dialect;
+    using Microsoft.Data.SqlClient;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using Particular.TimeoutMigrationTool.SqlP;
+    using RabbitMQ.Client;
+
+    class SqlTransportSource : ITimeoutsSource
+    {
+        const string tableSuffix = ".Delayed";
+        const int longRunningQueryTimeout = 1200;
+        readonly ILogger logger;
+        readonly SqlConnection connection;
+        readonly int batchSize;
+        string migrationRunId;
+
+        public SqlTransportSource(ILogger logger, string connectionString, int batchSize)
+        {
+            this.logger = logger;
+            this.batchSize = batchSize;
+            this.connection = new SqlConnection(connectionString);
+        }
+
+        public async Task Abort()
+        {
+            var toolState = await TryLoadOngoingMigration();
+
+            await using var command = connection.CreateCommand();
+
+            command.CommandTimeout = longRunningQueryTimeout;
+            command.CommandText = SqlConstants.GetScriptToAbort(migrationRunId, toolState.EndpointName);
+
+            var completedAtParameter = command.CreateParameter();
+            completedAtParameter.ParameterName = "CompletedAt";
+            completedAtParameter.Value = DateTime.UtcNow;
+            command.Parameters.Add(completedAtParameter);
+
+            await command.ExecuteNonQueryAsync();
+        }
+        public async Task<bool> CheckIfAMigrationIsInProgress()
+        {
+            var toolState = await TryLoadOngoingMigration();
+            return toolState != null;
+        }
+
+        public async Task Complete()
+        {
+            await EnsureConnectionOpen();
+            await using var command = connection.CreateCommand();
+
+            var migrationRunIdParameter = command.CreateParameter();
+            migrationRunIdParameter.ParameterName = "MigrationRunId";
+            migrationRunIdParameter.Value = migrationRunId;
+            command.Parameters.Add(migrationRunIdParameter);
+
+            var completedAtParameter = command.CreateParameter();
+            completedAtParameter.ParameterName = "CompletedAt";
+            completedAtParameter.Value = DateTime.UtcNow;
+            command.Parameters.Add(completedAtParameter);
+
+            command.CommandText = SqlConstants.MarkMigrationAsCompleted;
+
+            await command.ExecuteNonQueryAsync();
+        }
+        public async Task<IReadOnlyList<EndpointInfo>> ListEndpoints(DateTime cutOffTime)
+        {
+            await EnsureConnectionOpen();
+
+            var sql = string.Format(SqlConstants.ListEndPoints);
+            await using var listEndpointsCommand = new SqlCommand(sql, connection)
+            {
+                CommandType = CommandType.Text
+            };
+            var results = new List<EndpointInfo>();
+            var endpoints = new List<string>();
+            using (var reader = await listEndpointsCommand.ExecuteReaderAsync().ConfigureAwait(false))
+            {
+                if (reader.HasRows)
+                {
+                    while (await reader.ReadAsync())
+                    {
+                        var tableName = reader.GetString(0);
+                        endpoints.Add(tableName);
+                    }
+                }
+            }
+
+            foreach (var endpoint in endpoints)
+            {
+                var endpointName = endpoint.Replace(tableSuffix, string.Empty, StringComparison.InvariantCultureIgnoreCase);
+                await using var listEndPointDetailCommand = new SqlCommand(string.Format(SqlConstants.ListEndPointDetails, endpoint, endpointName), connection)
+                {
+                    CommandType = CommandType.Text
+                };
+                using (var endpointDetailsReader = await listEndPointDetailCommand.ExecuteReaderAsync().ConfigureAwait(false))
+                {
+                    if (endpointDetailsReader.HasRows)
+                    {
+                        while (await endpointDetailsReader.ReadAsync())
+                        {
+                            results.Add(new EndpointInfo
+                            {
+                                EndpointName = endpointDetailsReader.GetString(0).Replace(tableSuffix, string.Empty, StringComparison.InvariantCultureIgnoreCase),
+                                NrOfTimeouts = endpointDetailsReader.GetInt32(1),
+                                ShortestTimeout = endpointDetailsReader.IsDBNull(2) ? DateTime.MaxValue : endpointDetailsReader.GetDateTime(2),
+                                LongestTimeout = endpointDetailsReader.IsDBNull(3) ? DateTime.MaxValue : endpointDetailsReader.GetDateTime(3),
+                                Destinations = endpointDetailsReader.GetString(4).Split(", ", StringSplitOptions.RemoveEmptyEntries)
+                            });
+                        }
+                    }
+                }
+            }
+            return results;
+        }
+
+        public async Task MarkBatchAsCompleted(int number)
+        {
+            await EnsureConnectionOpen();
+            await using var command = connection.CreateCommand();
+
+            command.CommandText = SqlConstants.GetScriptToCompleteBatch(migrationRunId);
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "BatchNumber";
+            parameter.Value = number;
+
+            command.Parameters.Add(parameter);
+
+            await command.ExecuteNonQueryAsync();
+        }
+        public async Task MarkBatchAsStaged(int number)
+        {
+            await EnsureConnectionOpen();
+            await using var command = connection.CreateCommand();
+
+            command.CommandText = string.Format(SqlConstants.MarkBatchAsStaged, migrationRunId);
+
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "BatchNumber";
+            parameter.Value = number;
+            command.Parameters.Add(parameter);
+
+            await command.ExecuteNonQueryAsync();
+        }
+
+        public async Task<IToolState> Prepare(DateTime cutOffTime, string endpointName, IDictionary<string, string> runParameters)
+        {
+            migrationRunId = Guid.NewGuid().ToString().Replace("-", "");
+
+            await EnsureConnectionOpen();
+            await using var command = connection.CreateCommand();
+
+            command.CommandTimeout = longRunningQueryTimeout;
+            command.CommandText = SqlConstants.GetScriptToPrepareTimeouts(migrationRunId, endpointName, batchSize);
+
+            var runParametersParameter = command.CreateParameter();
+            runParametersParameter.ParameterName = "RunParameters";
+            runParametersParameter.Value = JsonConvert.SerializeObject(runParameters);
+            command.Parameters.Add(runParametersParameter);
+
+            var cutOffTimeParameter = command.CreateParameter();
+            cutOffTimeParameter.ParameterName = "CutOffTime";
+            cutOffTimeParameter.Value = cutOffTime;
+            command.Parameters.Add(cutOffTimeParameter);
+
+            var startedAtParameter = command.CreateParameter();
+            startedAtParameter.ParameterName = "StartedAt";
+            startedAtParameter.Value = DateTime.UtcNow;
+            command.Parameters.Add(startedAtParameter);
+
+            await command.ExecuteNonQueryAsync();
+
+            return await TryLoadOngoingMigration();
+        }
+
+        public async Task<IReadOnlyList<TimeoutData>> ReadBatch(int batchNumber)
+        {
+            await EnsureConnectionOpen();
+
+            var sql = SqlConstants.GetScriptToLoadBatch(migrationRunId);
+            await using var loadBatchCommand = new SqlCommand(sql, connection)
+            {
+                CommandType = CommandType.Text
+            };
+
+            var parameter = loadBatchCommand.CreateParameter();
+            parameter.ParameterName = "BatchNumber";
+            parameter.Value = batchNumber;
+
+            loadBatchCommand.Parameters.Add(parameter);
+
+            await using var reader = await loadBatchCommand.ExecuteReaderAsync();
+            List<TimeoutData> results = null;
+            if (reader.HasRows)
+            {
+                results = new List<TimeoutData>();
+                await foreach (var timeoutDataRow in ReadTimeoutDataRows(reader))
+                {
+                    results.Add(timeoutDataRow);
+                }
+            }
+
+            return results;
+        }
+        public async Task<IToolState> TryLoadOngoingMigration()
+        {
+            await EnsureConnectionOpen();
+            await using var command = connection.CreateCommand();
+
+            command.CommandText = SqlConstants.GetScriptToLoadPendingMigrations();
+
+            await using var reader = await command.ExecuteReaderAsync();
+
+            if (!await reader.ReadAsync())
+            {
+                return null;
+            }
+
+            migrationRunId = reader.GetString(0);
+            var endpoint = reader.GetString(1);
+            var status = (MigrationStatus)reader.GetInt32(2);
+            var runParameters = JsonConvert.DeserializeObject<Dictionary<string, string>>(reader.GetString(3));
+            var numberOfBatches = reader.GetInt32(4);
+
+            if (await reader.ReadAsync())
+            {
+                throw new Exception("Multiple uncompleted migrations found");
+            }
+
+            return new SqlTToolState(this.connection, migrationRunId, runParameters, endpoint, numberOfBatches, status);
+        }
+
+        private async ValueTask EnsureConnectionOpen()
+        {
+            if (connection.State != ConnectionState.Open)
+            {
+                await connection.OpenAsync().ConfigureAwait(false);
+            }
+        }
+        async IAsyncEnumerable<TimeoutData> ReadTimeoutDataRows(DbDataReader reader)
+        {
+            while (await reader.ReadAsync())
+            {
+                yield return new TimeoutData
+                {
+                    Id = reader.GetGuid(0).ToString(),
+                    Destination = reader.GetString(1),
+                    State = GetBytes(reader, 2),
+                    Time = reader.GetFieldValue<DateTime>(3),
+                    Headers = GetHeaders(reader)
+                };
+            }
+        }
+
+        byte[] GetBytes(DbDataReader reader, int ordinal)
+        {
+            byte[] result = null;
+
+            if (!reader.IsDBNull(ordinal))
+            {
+                var size = reader.GetBytes(ordinal, 0, null, 0, 0);
+                result = new byte[size];
+                const int bufferSize = 1024;
+                long bytesRead = 0;
+                var curPos = 0;
+
+                while (bytesRead < size)
+                {
+                    bytesRead += reader.GetBytes(ordinal, curPos, result, curPos, bufferSize);
+                    curPos += bufferSize;
+                }
+            }
+
+            return result;
+        }
+
+        Dictionary<string, string> GetHeaders(DbDataReader reader)
+        {
+            using var stream = reader.GetTextReader(4);
+            using var jsonReader = new JsonTextReader(stream);
+            return serializer.Deserialize<Dictionary<string, string>>(jsonReader);
+        }
+
+        static JsonSerializer serializer = JsonSerializer.Create(new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented,
+            DefaultValueHandling = DefaultValueHandling.Ignore
+        });
+    }
+}

--- a/src/TimeoutMigrationTool/TimeoutMigrationTool.csproj
+++ b/src/TimeoutMigrationTool/TimeoutMigrationTool.csproj
@@ -16,6 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.1" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
         <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />

--- a/src/TimeoutMigrationTool/TimeoutMigrationTool.csproj
+++ b/src/TimeoutMigrationTool/TimeoutMigrationTool.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Hi, 

I created this PR to address the changes we are currently taken to resolve https://github.com/Particular/TimeoutMigrationTool/issues/494. There is still work to be done in this PR to follow all the guidelines which you have in the others, but it already allows us to copy messages from the source to the target. 
So before adding more effort to this PR, I would like to discuss if it makes sense to add this source and target to the project. 

The scenario: 
_We have several endpoints using SQL Transport (SQL Island) but also endpoints using an Azure Service Bus Transport (ASB Island). Currently those are connected using the opensource project 'NServicebus.Router '. 
As this router is adding increased confusion and complexity, we would like to remove this and move all the endpoints to ASB only. This is planned to be completed by the end of Q1 2023. On the SQL Island we have several messages which are delayed by several months for up to a year. So we would need to move these messages as well, so we found that this project could be a good starting point._ 

# Actions done: 

## Create a SQLTransport source: 
This is mostly a copy of the existing (Not Native) Sql source which is afterwards adapted to the native SQLTransport. 

## Create a ASB target:  
This follows most of the guidelines which I saw in the other targets.  

## Things to be done 
- Add Integration Tests
- Add FakeData / Fake Targets
- overall clean up 
