### PR TITLE
Fix CI conflicts by giving each target framework independent endpoint names

### DIFF
--- a/src/TimeoutMigrationTool.Asp.AcceptanceTests/AspAcceptanceTest.cs
+++ b/src/TimeoutMigrationTool.Asp.AcceptanceTests/AspAcceptanceTest.cs
@@ -1,15 +1,15 @@
 ﻿namespace TimeoutMigrationTool.Asp.AcceptanceTests
 {
-    using Azure.Storage.Blobs;
-    using Microsoft.Azure.Cosmos.Table;
-    using Particular.TimeoutMigrationTool.Asp;
-    using NServiceBus;
-    using NUnit.Framework;
     using System;
     using System.IO;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure.Storage.Blobs;
+    using Microsoft.Azure.Cosmos.Table;
+    using NServiceBus;
+    using NUnit.Framework;
+    using Particular.TimeoutMigrationTool.Asp;
     using static Microsoft.Azure.Cosmos.Table.TableQuery;
 
     [TestFixture]
@@ -35,7 +35,10 @@
 
                 testName = testName.Replace("_", "");
 
-                return testName + "-" + endpointBuilder;
+                // A staging table from one framework run that is deleted will cause another attempt to create it to result in Conflict exception
+                // for several seconds after the delete occurs, causing a problem for other target framework test runs unless the endpoint
+                // names are different
+                return $"{testName}-{endpointBuilder}-net{Environment.Version.Major}";
             };
 
             tableNamePrefix = $"Att{Path.GetFileNameWithoutExtension(Path.GetTempFileName())}{DateTime.UtcNow.Ticks}".ToLowerInvariant();

--- a/src/TimeoutMigrationTool.Raven4.AcceptanceTests/RavenDBAcceptanceTest.cs
+++ b/src/TimeoutMigrationTool.Raven4.AcceptanceTests/RavenDBAcceptanceTest.cs
@@ -1,16 +1,16 @@
 ﻿namespace TimeoutMigrationTool.Raven4.AcceptanceTests
 {
-    using NUnit.Framework;
-    using Raven.Client.Documents;
-    using Raven.Client.ServerWide;
-    using Raven.Client.ServerWide.Operations;
     using System;
     using System.IO;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.TimeoutMigrationTool;
     using Particular.TimeoutMigrationTool.RavenDB;
+    using Raven.Client.Documents;
+    using Raven.Client.ServerWide;
+    using Raven.Client.ServerWide.Operations;
 
     public abstract class RavenDBAcceptanceTest
     {
@@ -32,9 +32,10 @@
 
                 testName = testName.Replace("_", "");
 
-                var result = testName + "." + endpointBuilder;
-                result = result.Replace('.', '-');
-                return result;
+                // A staging table from one framework run that is deleted will cause another attempt to create it to result in Conflict exception
+                // for several seconds after the delete occurs, causing a problem for other target framework test runs unless the endpoint
+                // names are different
+                return $"{testName}-{endpointBuilder}-net{Environment.Version.Major}";
             };
 
             serverUrl = Environment.GetEnvironmentVariable(EnvironmentVariables.Raven4Url);


### PR DESCRIPTION
For Azure Storage, a conflict happens in the tests:

> Unable to create staging queue 'delays879ce3b51b70b8ef2322569731cec26a220776fastaging'. Exception message 'Conflict'

As part of the migration process, it actually creates a **table** (so the error message "staging queue" is misleading) named `delaysXXXXXstaging` where the X's are a hash of the endpoint name. This is actually driven by the delayed delivery capability of the Azure Storage Queues transport, with `delaysXXXXX` being a thing used by the transport, and the migration process is only creating something with `staging` tacked on to the end.

What is currently happening is that the `net6.0` tests run and successfully do a migration, and clean up the staging queue. But then the `net7.0` tests start running not long after … quickly enough that Azure Tables returns a Conflict exception when the tests try to create a new table with the same name as the very-recently-deleted one.

So even in Visual Studio, running the test again too fast after a success will cause it to fail. The solution is to change the endpoint names. The test conventions only allow doing this by type, where we don't have access to the test context's unique RunId, so the best thing we can do to disambiguate the test runs is to add the .NET version into the endpoint name as well.